### PR TITLE
release: finalize v0.3.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-19
+
 ### Added
 
 - Codex 本地 Provider 增加 `--reasoning-effort`，运行清单记录 Provider、模型、推理强度、Codex CLI、pdf2zh-next 与 BabelDOC 版本。

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,46 @@
+# PaperLocale v0.3.0
+
+v0.3.0 是首个经过真实 13 页大气科学论文试运行反向校准的功能版本。该版本不
+分发受版权保护的源论文或完整译本，只把真实运行暴露的问题固化为通用代码、
+项目自有合成夹具和可审计质量门禁。
+
+## 主要变化
+
+- `codex-local` 原生支持 `--reasoning-effort`，并要求显式模型；schema 3 清单
+  记录 Provider、模型、推理强度、Codex CLI、pdf2zh-next、BabelDOC 和领域包
+  内容 SHA-256。
+- 参考文献默认 `preserve`。系统只自动接受源 PDF 唯一 `REFERENCES` 区域内的
+  确定性完整匹配，并在任何模型调用前要求人工确认哈希绑定映射；另提供显式
+  `translate-titles`。
+- 同一模型批次存在失败候选时，其他已通过门禁的译文仍会原子保存，失败候选
+  和具体错误进入 `rejected_translations.jsonl`。
+- PDF QA 在矢量绘图减少时记录页码、边界框和面积，并在逐页对照图两侧红框
+  定位；`apply-vector-repair` 会备份旧 PDF、记录 `repair_history` 并重置 QA。
+- 修复 `ABSTRACT`、`KEYWORDS`、`REFERENCES` 缩写假阳性，以及
+  `mid-1960s` 被误识别为负数的问题。
+
+## 行为变化
+
+- 新的 Codex 本地运行必须显式提供 `--model`；`--reasoning-effort` 可选。
+- 默认参考文献策略会在 collect 后暂停，生成 `reference_review.jsonl`；执行
+  `confirm-references` 后重新运行原命令才能开始翻译。
+- 旧 schema 1/2 运行仍可按既有证据边界重新 QA；新翻译运行使用 schema 3。
+
+## 验证证据
+
+- [PR #6](https://github.com/hazugi2004/paperlocale/pull/6) 已通过远端 Python
+  3.10、3.11、3.12、3.13 四版本矩阵；
+- 53 项测试全部不调用模型，覆盖参考文献乱序、领域包内容身份、批内部分成功、
+  小型链接矢量图标缺失和受控修复；
+- wheel 与 sdist 已构建，确切 wheel 已在全新 Python 3.12 环境安装并启动 CLI；
+- 本地真实版面环境为 pdf2zh-next 2.9.0 / BabelDOC 0.6.2；真实论文仅用于本地
+  验证，不进入仓库或发行附件。
+
+## 已知边界
+
+- CLITranslator 当前不提供页码或版面语义角色，因此不确定的参考文献片段必须
+  人工确认；项目不会使用作者年份或 DOI 密度进行静默猜测。
+- 机器 QA 不能替代逐页视觉验收；任何候选 PDF 仍需显式执行 `accept`。
+- `--clitranslator-command` 的长期上游稳定性仍在
+  [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)
+  等待维护者确认。


### PR DESCRIPTION
## Summary

- move the completed v0.3.0 changes from `Unreleased` into a dated changelog section
- add release notes covering user-visible changes, validation evidence, migration behavior, and known upstream boundaries

## Validation

- documentation-only diff
- `git diff --check`
- based on merged PR #6, whose Python 3.10–3.13 matrix passed

## Release boundary

Merge this PR before creating the `v0.3.0` tag so the tagged source contains its final changelog and release notes.