### PR TITLE
docs: record v0.3.1 release evidence

### DIFF
--- a/docs/ADOPTION_EVIDENCE.zh-CN.md
+++ b/docs/ADOPTION_EVIDENCE.zh-CN.md
@@ -15,6 +15,8 @@
 
 [v0.3.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.0) 根据本地真实 13 页论文试运行增加可审计参考文献确认、Provider/模型/版面引擎溯源、批内部分成功恢复、矢量缺失定位和受控修复，并由 53 项测试覆盖 Python 3.10–3.13。标签构建完成元数据检查和确切 wheel 安装，公开附件哈希已重新下载复核。该版本证明维护者能把真实边界转化为通用发布能力，但仍属于维护者证据，不是外部采用。
 
+发布后的干净 Runner 检查发现 v0.3.0 的 `PyMuPDF>=1.26` 与 `pdf2zh-next 2.9.x` 约束冲突。维护者先公开保留[失败运行](https://github.com/hazugi2004/paperlocale/actions/runs/32219957135)，再通过 [PR #10](https://github.com/hazugi2004/paperlocale/pull/10) 修复依赖和增加独立 `[layout]` 求解门禁，并发布 [v0.3.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1)。[v0.3.1 标签兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819)完成真实两阶段版面流程且 QA 错误为 0；[标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32221420406)从确切 wheel 复核了 `[layout]`。公开重新下载附件的 SHA-256 为 `3c590e16a62419e07025f6f4ccc246d029f8345de2fff7a17ca2069c47aef873`（wheel）和 `f91b41a736944cde17fdc2386115fd807bee6a139180085aaaa5dec8746bd355`（sdist）。这些仍是维护者维护能力与可复现性证据，不是外部采用。
+
 维护者还在 PDFMathTranslate-next 上游发布了
 [CLITranslator 两阶段集成讨论 #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)，并在 v0.2.0 发布后补充了[真实兼容性与标签构建证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545)。它证明上游沟通和可复现跟进已经开始；在上游维护者或其他参与者回复前，它仍不构成外部认可或采用。
 
@@ -32,6 +34,7 @@
 | 2026-08-18 | 维护者补丁 Release | [v0.1.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.1.1) | 发布后审计、27 项测试、远端构建 | 否 |
 | 2026-08-18 | 功能 Release | [v0.2.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.2.0) | 一键运行、结构门禁、Provider 评估、37 项测试与发行构建 | 否 |
 | 2026-08-19 | 功能 Release | [v0.3.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.0) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32219122015) | 真实试运行反向校准、参考文献审计、53 项测试、发行附件哈希 | 否 |
+| 2026-08-19 | 维护者兼容性热修复 | [v0.3.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32221420406) / [标签兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819) | 公开保留失败证据后修复 `[layout]` 安装；54 项测试、确切 wheel 依赖求解、真实版面 QA 0 错误、附件哈希复核 | 否 |
 | 2026-08-18 | 维护者发起的上游讨论 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354) | 两阶段 CLITranslator 接口稳定性与文档协作请求 | 否，等待外部回复 |
 | 2026-08-19 | 维护者上游跟进 | [v0.2.0 兼容性证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545) | 真实兼容性运行、标签构建和结构 QA 证据 | 否，等待外部回复 |
 | 2026-08-18 | 外部 fork 与 Draft PR | [PR #4](https://github.com/hazugi2004/paperlocale/pull/4) / [CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274) | 非维护者响应 good first issue；贡献分支 CI 通过，维护者将其与最新主线组合验证 36 项测试并批准 | 是，尚未合并 |

--- a/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
@@ -9,7 +9,7 @@
 - Project: PaperLocale
 - Repository: https://github.com/hazugi2004/paperlocale
 - Core maintainer: `hazugi2004`
-- Role evidence: 仓库管理员、提交者和 `v0.1.0` / `v0.1.1` / `v0.2.0` / `v0.3.0` 发布者
+- Role evidence: 仓库管理员、提交者和 `v0.1.0` / `v0.1.1` / `v0.2.0` / `v0.3.0` / `v0.3.1` 发布者
 - License: AGPL-3.0-only
 
 ## 英文项目简介
@@ -26,7 +26,10 @@
 
 ## 已有证据链接
 
-- Latest release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.0
+- Latest release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1
+- v0.3.1 hotfix PR: https://github.com/hazugi2004/paperlocale/pull/11
+- v0.3.1 release build: https://github.com/hazugi2004/paperlocale/actions/runs/32221420406
+- v0.3.1 layout compatibility run: https://github.com/hazugi2004/paperlocale/actions/runs/32221715819
 - v0.3.0 implementation PR: https://github.com/hazugi2004/paperlocale/pull/6
 - v0.3.0 release build: https://github.com/hazugi2004/paperlocale/actions/runs/32219122015
 - Initial release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.1.0
@@ -41,7 +44,7 @@
 
 ## 提交前仍需补强
 
-项目已连续发布四个版本，并完成第二个主要功能 Release；首个非维护者 fork 与 Draft PR 也已经出现，但仍不能代替真实使用或已合并贡献。以下再完成任意两类外部证据后，申请说服力会显著提高：
+项目已发布五个版本，完成第二个主要功能 Release，并在公开失败证据后交付安装兼容性热修复；首个非维护者 fork 与 Draft PR 也已经出现，但仍不能代替真实使用或已合并贡献。以下再完成任意两类外部证据后，申请说服力会显著提高：
 
 1. 将外部 [PR #4](https://github.com/hazugi2004/paperlocale/pull/4) 或后续外部 PR 完成合并；
 2. 至少一个非维护者提交的真实试用反馈或可复现问题报告；

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -18,12 +18,12 @@ OpenAI 官方页面说明，该计划面向开源维护者，权益包括：
 |---|---|---|
 | 明确的公共开源价值 | 学术 PDF 保版翻译、科学信息硬门禁、可扩展领域术语包 | 已实现 |
 | 核心维护者与写权限 | `MAINTAINERS.md` 与 GitHub `hazugi2004/paperlocale` 管理权限 | 已验证 |
-| 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献人工确认、单向状态机、53 项不联网测试 | [v0.3.0 PR #6](https://github.com/hazugi2004/paperlocale/pull/6) 与 Python 3.10–3.13 矩阵已通过 |
+| 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献人工确认、单向状态机、54 项不联网测试 | [v0.3.1 PR #11](https://github.com/hazugi2004/paperlocale/pull/11) 的 Python 3.10–3.13 矩阵及 `[layout]` 依赖求解门禁已通过 |
 | 可复现质量证据 | 合成双栏 PDF、公式合同、图片与矢量绘图硬门禁、逐页 QA | 已实现 |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |
 | 可公开演示 | 自有合成论文的原文、译文与全页 QA GIF | 已实现 |
-| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建和上游兼容性工作流 | v0.1.0–v0.3.0、[v0.3.0 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32219122015)与[首次真实兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32152325669)已通过 |
-| 公开版本 | [GitHub v0.3.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.0) | 已发布，wheel 与 sdist 附件哈希已复核 |
+| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建和上游兼容性工作流 | v0.1.0–v0.3.1、[v0.3.1 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32221420406)与[标签级真实兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819)已通过 |
+| 公开版本 | [GitHub v0.3.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1) | 已发布；确切 wheel 的 `[layout]` 求解通过，wheel 与 sdist 附件哈希已复核 |
 | 外部贡献 | 非维护者 fork 与 [两页 PDF QA Draft PR #4](https://github.com/hazugi2004/paperlocale/pull/4)；[贡献分支 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)及其与最新主线组合验证的 36 项测试均通过，维护者已批准 | 初步证据，等待作者标记 Ready 并合并 |
 | 广泛使用或真实用户采用 | 尚无非维护者真实翻译反馈、问题报告或下游引用 | 未证明 |
 | 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354) 与 [v0.2.0 证据跟进](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545) 已发出 | 已持续跟进，尚无外部回应 |

--- a/docs/COMMUNITY_OUTREACH_DRAFTS.zh-CN.md
+++ b/docs/COMMUNITY_OUTREACH_DRAFTS.zh-CN.md
@@ -47,7 +47,7 @@
 >
 > 重点保护公式占位符、富文本标签、数字、单位、缩写、URL、DOI 和固定专业术语；源 PDF、候选 PDF 与 QA 报告通过 SHA-256 绑定。候选文件在 QA 后被替换时，验收会直接失败。
 >
-> 当前版本为 v0.3.0，已有 53 项测试覆盖 Python 3.10–3.13，并提供断点续跑、参考文献人工确认、真实 Provider 领域案例评估和逐页机器 QA；图片或矢量绘图少于原文时 QA 会失败并红框定位。真实版面冒烟包含双栏、公式、矢量表格和嵌入图片，并提供由自有合成论文生成的演示 GIF。项目不会分发受版权限制的论文或完整译本。
+> 当前版本为 v0.3.1，已有 54 项测试覆盖 Python 3.10–3.13，并提供断点续跑、参考文献人工确认、真实 Provider 领域案例评估和逐页机器 QA；图片或矢量绘图少于原文时 QA 会失败并红框定位。v0.3.1 已在干净 Linux Runner 上从 `[layout]` 安装完成真实版面冒烟，覆盖双栏、公式、矢量表格和嵌入图片，并提供由自有合成论文生成的演示 GIF。项目不会分发受版权限制的论文或完整译本。
 >
 > 目前最需要的不是单纯 Star，而是实际试用反馈、Linux 安装复核、新领域术语包和可复现的版面问题。仓库中已经准备了 3 个 good first issues。
 
@@ -57,7 +57,7 @@
 >
 > It supports an authenticated local Codex session and BYOK OpenAI-compatible endpoints, while enforcing hard gates for formulas, style placeholders, numbers, units, abbreviations, URLs, DOIs, and domain terminology. The source PDF, rendered candidate, and QA report are SHA-256 bound, and every page must be reviewed before acceptance.
 >
-> v0.3.0 has 53 model-free tests across Python 3.10–3.13, resumable translation, hash-bound human reference confirmation, reproducible Provider evaluation, vector-loss localization, and a real PDFMathTranslate-next/BabelDOC smoke path covering two columns, formulas, a vector table, and an embedded image. No copyrighted research paper or full translation is distributed.
+> v0.3.1 has 54 model-free tests across Python 3.10–3.13, resumable translation, hash-bound human reference confirmation, reproducible Provider evaluation, vector-loss localization, and a clean-Linux PDFMathTranslate-next/BabelDOC smoke path covering two columns, formulas, a vector table, and an embedded image. No copyrighted research paper or full translation is distributed.
 >
 > I am looking for reproducible feedback, Linux installation verification, and contributors for additional scientific domain packs. Three scoped good first issues are open.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,6 +64,7 @@
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release
 - [x] GitHub `v0.3.0` 真实试运行反向校准、参考文献审计与恢复语义 Release
+- [x] GitHub `v0.3.1` 版面依赖兼容性热修复与确切 wheel `[layout]` 求解验证
 - [x] 三个有验收标准的 good first issues
 - [x] 自有合成论文的原文、译文与全页 QA 演示 GIF
 

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -23,7 +23,7 @@ v0.3.1 是 v0.3.0 的版面安装兼容性热修复，不改变翻译合同、�
   [PR #10](https://github.com/hazugi2004/paperlocale/pull/10) 的 Python 3.10–3.13
   矩阵和独立 `[layout]` 依赖求解任务全部通过；
 - 54 项不联网测试通过；
-- [干净 Runner 真实兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32220623165)
+- [v0.3.1 标签真实兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819)
   安装 `pdf2zh-next 2.9.0 / BabelDOC 0.6.2`，完成
   `collect -> reference confirm -> translate -> validate -> render -> qa`；
 - 公开审计产物的运行清单为 `qa_generated`，参考文献策略为 `preserve`、映射为空且


### PR DESCRIPTION
## Summary
- update the application draft, readiness checklist, roadmap, and outreach drafts to v0.3.1 / 54 tests
- record the failed v0.3.0 layout install run, the bounded fix, the successful tag build, and the tag-level real layout smoke
- record public re-download hashes for the v0.3.1 wheel and sdist
- continue to classify all of this as maintainer evidence, not external adoption

## Public evidence
- release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1
- release build: https://github.com/hazugi2004/paperlocale/actions/runs/32221420406
- tag-level layout compatibility: https://github.com/hazugi2004/paperlocale/actions/runs/32221715819
- original failed run retained for audit: https://github.com/hazugi2004/paperlocale/actions/runs/32219957135

## Validation
- documentation-only change
- Markdown diff/whitespace check
- tag compatibility artifact independently downloaded and inspected: `qa_generated`, pdf2zh-next 2.9.0, BabelDOC 0.6.2, confirmed empty preserve map, zero QA errors, comparison PNG and demo GIF present