### PR TITLE
docs: use noneditable install for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ git clone https://github.com/hazugi2004/paperlocale.git
 cd paperlocale
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e ".[layout]"
+python -m pip install ".[layout]"
 paperlocale domain-check atmospheric-science
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,7 +61,7 @@ git clone https://github.com/hazugi2004/paperlocale.git
 cd paperlocale
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e ".[layout]"
+python -m pip install ".[layout]"
 paperlocale domain-check atmospheric-science
 ```
 


### PR DESCRIPTION
## Summary
- change the ordinary English and Chinese installation paths from editable to non-editable installs
- keep editable installs in the development/contributor sections

## Why
The v0.3.1 hotfix and external Ubuntu verification issue now treat a clean, non-editable `.[layout]` install as the user-facing baseline. The top-level READMEs should match that tested path.

## Validation
- English and Chinese install snippets agree
- development snippets still use `-e`
- Markdown diff/whitespace check