### PR TITLE
ci: verify macOS Unicode path install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,35 @@ permissions:
   contents: read
 
 jobs:
+  macos-noneditable-path-install:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install and run from Chinese and space paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          # 真实论文试运行曾在 macOS editable 安装中遇到异常 .pth；普通用户路径已
+          # 改为非 editable。这里同时把源码和虚拟环境放入含中文与空格的隔离路径，
+          # 验证推荐安装方式不依赖仓库原路径，也能直接启动已安装的 CLI 入口。
+          isolated_root="$(mktemp -d)"
+          source_root="$isolated_root/中文 项目"
+          venv_root="$isolated_root/中文 环境"
+          mkdir -p "$source_root"
+          git archive HEAD | tar -x -C "$source_root"
+          python -m venv "$venv_root"
+          "$venv_root/bin/python" -m pip install "$source_root"
+          "$venv_root/bin/python" -m pip check
+          "$venv_root/bin/paperlocale" domain-check atmospheric-science
+          "$venv_root/bin/python" -c \
+            'import paperlocale; print(paperlocale.__version__)'
+
   layout-dependency-resolution:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Added
+
+- macOS CI 在源码目录和虚拟环境都含中文与空格时执行非 editable 安装、`pip check`、领域包检查和 CLI 入口验证，覆盖普通用户推荐安装路径。
+
 ## 0.3.1 - 2026-08-19
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add a macOS 3.12 CI job for the ordinary non-editable install path
- place both the archived source tree and isolated virtual environment under paths containing Chinese characters and spaces
- run pip dependency validation, the installed CLI entry point, domain-pack validation, and a package version import
- document the new gate in the Unreleased changelog

## Evidence boundary
A real macOS run previously observed an abnormal hidden editable `.pth`. This change does not claim a general pip bug or patch editable installs. It verifies the recommended non-editable user path that avoids that observed failure mode.

## Local validation
- workflow YAML parse
- exact job commands on macOS with `中文 项目` and `中文 环境`
- `pip check`: no broken requirements
- installed `paperlocale domain-check atmospheric-science`
- imported version: 0.3.1