### PR TITLE
docs: record v0.3.2 release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Documentation
 
-- 按 BabelDOC 贡献规范提交上游 [Issue #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与一行修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611)，解决同文返回仍触发重排的对象类型比较错误；合并和发版仍由上游决定。
+- 按 BabelDOC 贡献规范提交上游 [Issue #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与最小修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611)，解决同文返回仍触发重排的对象类型比较错误；合并和发版仍由上游决定。
 
 ## 0.3.1 - 2026-08-19
 

--- a/docs/ADOPTION_EVIDENCE.zh-CN.md
+++ b/docs/ADOPTION_EVIDENCE.zh-CN.md
@@ -21,15 +21,18 @@
 本地 27 页、79 片段真实论文试运行，把行号参考文献识别、非正文人工透传、碎词
 安全审查和 schema 4 溯源分别通过 [PR #17](https://github.com/hazugi2004/paperlocale/pull/17)、
 [#18](https://github.com/hazugi2004/paperlocale/pull/18) 与
-[#19](https://github.com/hazugi2004/paperlocale/pull/19) 交付，并由 63 项测试和
-自有合成 PDF 完整版面闭环验证。真实论文及完整译本未上传或分发；该证据仍是
-维护者测试，不是外部用户采用。
+[#19](https://github.com/hazugi2004/paperlocale/pull/19) 交付，并由 63 项测试、
+[标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229) 和
+[公开版面兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)
+验证。[永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)
+SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`。
+真实论文及完整译本未上传或分发；该证据仍是维护者测试，不是外部用户采用。
 
 维护者还在 PDFMathTranslate-next 上游发布了
 [CLITranslator 两阶段集成讨论 #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)，并在 v0.2.0 发布后补充了[真实兼容性与标签构建证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545)。它证明上游沟通和可复现跟进已经开始；在上游维护者或其他参与者回复前，它仍不构成外部认可或采用。
 
 针对同文返回仍触发重排的 BabelDOC 核心错误，维护者另提交了
-[Issue #610](https://github.com/funstory-ai/BabelDOC/issues/610) 和一行修复及回归
+[Issue #610](https://github.com/funstory-ai/BabelDOC/issues/610) 和最小修复及回归
 测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611)。本地测试和 Ruff
 通过，但上游首次 fork Actions 仍等待维护者批准运行；在获得审查或合并前，它只
 证明主动上游协作，不属于外部认可。
@@ -49,10 +52,10 @@
 | 2026-08-18 | 功能 Release | [v0.2.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.2.0) | 一键运行、结构门禁、Provider 评估、37 项测试与发行构建 | 否 |
 | 2026-08-19 | 功能 Release | [v0.3.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.0) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32219122015) | 真实试运行反向校准、参考文献审计、53 项测试、发行附件哈希 | 否 |
 | 2026-08-19 | 维护者兼容性热修复 | [v0.3.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32221420406) / [标签兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819) / [永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.1/paperlocale-v0.3.1-layout-compatibility.zip) | 公开保留失败证据后修复 `[layout]` 安装；54 项测试、确切 wheel 依赖求解、真实版面 QA 0 错误、附件哈希复核 | 否 |
-| 2026-08-19 | 功能 Release | [v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) / [PR #17](https://github.com/hazugi2004/paperlocale/pull/17) / [#18](https://github.com/hazugi2004/paperlocale/pull/18) / [#19](https://github.com/hazugi2004/paperlocale/pull/19) | 第二次真实试运行反向校准、schema 4、人工透传、碎词安全审查与 63 项测试 | 否 |
+| 2026-08-19 | 功能 Release | [v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229) / [兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256) / [永久附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip) | 第二次真实试运行反向校准、schema 4、人工透传、碎词安全审查、63 项测试与公开附件哈希 | 否 |
 | 2026-08-18 | 维护者发起的上游讨论 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354) | 两阶段 CLITranslator 接口稳定性与文档协作请求 | 否，等待外部回复 |
 | 2026-08-19 | 维护者上游跟进 | [v0.2.0 兼容性证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545) | 真实兼容性运行、标签构建和结构 QA 证据 | 否，等待外部回复 |
-| 2026-08-19 | 维护者上游修复 | [BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) / [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 同文返回保持原版面对象的一行修复和回归测试 | 否，等待上游审查 |
+| 2026-08-19 | 维护者上游修复 | [BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) / [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 同文返回保持原版面对象的最小修复和回归测试；两条自动审查意见已处理 | 否，等待上游维护者审查 |
 | 2026-08-18 | 外部 fork 与 Draft PR | [PR #4](https://github.com/hazugi2004/paperlocale/pull/4) / [CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274) | 非维护者响应 good first issue；贡献分支 CI 通过，维护者将其与最新主线组合验证 36 项测试并批准 | 是，尚未合并 |
 | 待记录 | 真实试用反馈 / Issue / 引用 / 下游项目 / 下载统计 | 待记录 | 待记录 | 是 / 否 |
 

--- a/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
@@ -32,6 +32,9 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 ## 已有证据链接
 
 - Latest release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2
+- v0.3.2 release build: https://github.com/hazugi2004/paperlocale/actions/runs/32234314229
+- v0.3.2 layout compatibility run: https://github.com/hazugi2004/paperlocale/actions/runs/32234356256
+- Durable v0.3.2 compatibility artifact: https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip
 - v0.3.2 reference-section PR: https://github.com/hazugi2004/paperlocale/pull/17
 - v0.3.2 audited passthrough PR: https://github.com/hazugi2004/paperlocale/pull/18
 - v0.3.2 segment-safety PR: https://github.com/hazugi2004/paperlocale/pull/19

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -25,14 +25,14 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 | 明确的公共开源价值 | 学术 PDF 保版翻译、科学信息硬门禁、可扩展领域术语包 | 已实现 |
 | 核心维护者与写权限 | `MAINTAINERS.md` 与 GitHub `hazugi2004/paperlocale` 管理权限 | 已验证 |
 | 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献与非正文人工确认、碎词安全审查、单向状态机、63 项不联网测试 | [PR #17](https://github.com/hazugi2004/paperlocale/pull/17)、[#18](https://github.com/hazugi2004/paperlocale/pull/18)、[#19](https://github.com/hazugi2004/paperlocale/pull/19) 的 Python 3.10–3.13 矩阵、macOS 中文/空格路径及 `[layout]` 求解均通过 |
-| 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.1 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.1/paperlocale-v0.3.1-layout-compatibility.zip)保留既有版面证据 | v0.3.2 合成版面闭环为 0 errors / 0 warnings；既有附件 SHA-256 为 `cac1e404b2317316551c98c060ca3649fdd4353f58502bb04442799fcba6781f` |
+| 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图 | [公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)为 0 errors / 0 warnings；附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |
 | 可公开演示 | 自有合成论文的原文、译文与全页 QA GIF | 已实现 |
-| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建和上游兼容性工作流 | v0.1.0–v0.3.2；[标签构建工作流](https://github.com/hazugi2004/paperlocale/actions/workflows/release-build.yml)验证发行元数据、确切 wheel 与 `[layout]` 求解 |
-| 公开版本 | [GitHub v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) | 已发布；参考文献默认仍为 `preserve`，BabelDOC 对象级修复等待上游合并 |
+| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建和上游兼容性工作流 | v0.1.0–v0.3.2；[v0.3.2 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229)验证发行元数据、确切 wheel 与 `[layout]` 求解 |
+| 公开版本 | [GitHub v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) | 已发布并设为 latest，三个附件已公开重下载复核；参考文献默认仍为 `preserve` |
 | 外部贡献 | 非维护者 fork 与 [两页 PDF QA Draft PR #4](https://github.com/hazugi2004/paperlocale/pull/4)；[贡献分支 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)及其与最新主线组合验证的 36 项测试均通过，维护者已批准 | 初步证据，等待作者标记 Ready 并合并 |
 | 广泛使用或真实用户采用 | 尚无非维护者真实翻译反馈、问题报告或下游引用 | 未证明 |
-| 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)、[BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与一行修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 维护者已主动提交；尚无上游回应或合并，首次 fork Actions 等待上游批准运行 |
+| 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)、[BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与最小修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 两条自动审查意见已在[提交 `735c381`](https://github.com/hazugi2004/BabelDOC/commit/735c3815869af78ed1b1c6cdf416a70cf958e4a5)中处理；尚无上游维护者回应或合并，首次 fork Actions 等待批准运行 |
 
 在 #354 获得回复前，项目临时按当前 `CLITranslator` 契约继续开发，并由每周真实版面冒烟工作流验证依赖范围内最新 2.x 版本。该策略降低等待成本，但不等同于上游兼容性承诺。
 

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -26,7 +26,7 @@ v0.3.2 把第二次真实论文试运行暴露的四类边界收敛为可审计�
 BabelDOC 贡献规范提交：
 
 - [BabelDOC Issue #610](https://github.com/funstory-ai/BabelDOC/issues/610)；
-- [BabelDOC PR #611](https://github.com/funstory-ai/BabelDOC/pull/611)：一行修复和
+- [BabelDOC PR #611](https://github.com/funstory-ai/BabelDOC/pull/611)：最小修复和
   一个对象身份回归测试。
 
 本地测试为 1/1 通过，Ruff 通过。首次 fork 的上游 Actions 当前需要维护者批准
@@ -63,3 +63,22 @@ BabelDOC 贡献规范提交：
 - 机器 QA 的 0 errors / 0 warnings 不代表视觉完全正确，最终 PDF 仍必须逐页
   人工验收；
 - 本版本继续固定到已验证的 `pdf2zh-next 2.9.x / BabelDOC 0.6.x` 兼容范围。
+
+## 发布后公开验证
+
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229)
+  通过发行元数据、确切 wheel 安装、领域包和 `[layout]` 求解；
+- [公开版面兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)
+  为 schema 4、3/3 片段闭合、1 条审计透传、0 errors / 0 warnings，逐页对照已
+  人工查看；
+- [永久版面审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)
+  包含日志、参考文献与透传映射、安全清单、运行清单和逐页 QA。
+
+公开附件 SHA-256：
+
+- `paperlocale-0.3.2-py3-none-any.whl`：
+  `594687d6fc474963a485682717cdd746a3d62f6af99cd7fc5611e9bcdfcf04f1`；
+- `paperlocale-0.3.2.tar.gz`：
+  `a79570a6d30c4e2c0f2b73d4a4cc292a933b8faf8714a12f4075f6e7ba5a9dfa`；
+- `paperlocale-v0.3.2-layout-compatibility.zip`：
+  `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`。


### PR DESCRIPTION
## Summary

- record the successful v0.3.2 tag build and public layout compatibility run
- publish stable links and SHA-256 values for all three re-downloaded release assets
- update application/readiness/adoption evidence to reference the permanent schema 4 audit ZIP
- correct the BabelDOC #611 description from a one-line patch to a minimal normalized-input fix
- record that both automated review findings were addressed in upstream commit 735c381 while maintainer review remains pending

## Verified evidence

- release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2
- tag build: https://github.com/hazugi2004/paperlocale/actions/runs/32234314229
- layout compatibility: https://github.com/hazugi2004/paperlocale/actions/runs/32234356256
- permanent audit ZIP SHA-256: `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`

This PR changes documentation only and does not alter the v0.3.2 tag or release binaries.