### PR TITLE
docs: update BabelDOC review status

### DIFF
--- a/docs/ADOPTION_EVIDENCE.zh-CN.md
+++ b/docs/ADOPTION_EVIDENCE.zh-CN.md
@@ -55,7 +55,7 @@ SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`�
 | 2026-08-19 | 功能 Release | [v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229) / [兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256) / [永久附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip) | 第二次真实试运行反向校准、schema 4、人工透传、碎词安全审查、63 项测试与公开附件哈希 | 否 |
 | 2026-08-18 | 维护者发起的上游讨论 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354) | 两阶段 CLITranslator 接口稳定性与文档协作请求 | 否，等待外部回复 |
 | 2026-08-19 | 维护者上游跟进 | [v0.2.0 兼容性证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545) | 真实兼容性运行、标签构建和结构 QA 证据 | 否，等待外部回复 |
-| 2026-08-19 | 维护者上游修复 | [BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) / [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 同文返回保持原版面对象的最小修复和回归测试；两条自动审查意见已处理 | 否，等待上游维护者审查 |
+| 2026-08-19 | 维护者上游修复 | [BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) / [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 同文返回保持原版面对象的最小修复和回归测试；三条自动审查意见已处理 | 否，等待上游维护者审查 |
 | 2026-08-18 | 外部 fork 与 Draft PR | [PR #4](https://github.com/hazugi2004/paperlocale/pull/4) / [CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274) | 非维护者响应 good first issue；贡献分支 CI 通过，维护者将其与最新主线组合验证 36 项测试并批准 | 是，尚未合并 |
 | 待记录 | 真实试用反馈 / Issue / 引用 / 下游项目 / 下载统计 | 待记录 | 待记录 | 是 / 否 |
 

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -32,7 +32,7 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 | 公开版本 | [GitHub v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) | 已发布并设为 latest，三个附件已公开重下载复核；参考文献默认仍为 `preserve` |
 | 外部贡献 | 非维护者 fork 与 [两页 PDF QA Draft PR #4](https://github.com/hazugi2004/paperlocale/pull/4)；[贡献分支 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)及其与最新主线组合验证的 36 项测试均通过，维护者已批准 | 初步证据，等待作者标记 Ready 并合并 |
 | 广泛使用或真实用户采用 | 尚无非维护者真实翻译反馈、问题报告或下游引用 | 未证明 |
-| 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)、[BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与最小修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 两条自动审查意见已在[提交 `735c381`](https://github.com/hazugi2004/BabelDOC/commit/735c3815869af78ed1b1c6cdf416a70cf958e4a5)中处理；尚无上游维护者回应或合并，首次 fork Actions 等待批准运行 |
+| 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)、[BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与最小修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 三条自动审查意见均已处理，最新为[提交 `be8b888`](https://github.com/hazugi2004/BabelDOC/commit/be8b88895f1e432d6bdaa97d3192d874f6f67732)；尚无上游维护者回应或合并，首次 fork Actions 等待批准运行 |
 
 在 #354 获得回复前，项目临时按当前 `CLITranslator` 契约继续开发，并由每周真实版面冒烟工作流验证依赖范围内最新 2.x 版本。该策略降低等待成本，但不等同于上游兼容性承诺。
 


### PR DESCRIPTION
## Summary

- update the upstream evidence count from two to three automated review findings
- link the latest BabelDOC fork commit `be8b888`, which centralizes punctuation normalization across both translation paths
- keep the boundary explicit: no upstream maintainer response, merge, or approved Actions run is claimed

Documentation only; PaperLocale code and v0.3.2 release assets are unchanged.