### PR TITLE
docs: add community and citation metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Added
+
+- 增加 Contributor Covenant 3.0 社区准则和 CFF 1.2.0 学术软件引用元数据，完善私密行为问题报告与 GitHub “Cite this repository” 入口。
+
 ## 0.3.2 - 2026-08-19
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use PaperLocale in research or teaching, please cite this software using these metadata."
+title: "PaperLocale: Verified layout-preserving academic PDF translation"
+type: software
+authors:
+  - name: "PaperLocale contributors"
+abstract: "PaperLocale is an auditable workflow for translating academic PDFs while preserving page structure, figures, tables, formulas, protected scientific information, and human-reviewed quality evidence."
+version: "0.3.2"
+date-released: "2026-08-19"
+repository-code: "https://github.com/hazugi2004/paperlocale"
+repository-artifact: "https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2"
+license: AGPL-3.0-only
+keywords:
+  - academic PDF
+  - atmospheric science
+  - layout-preserving translation
+  - research software
+  - scientific translation

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,52 @@
+# PaperLocale Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in PaperLocale welcoming, safe, and equitable.
+Everyone who participates in good faith receives the same opportunity to use,
+discuss, and improve the project.
+
+## Expected behavior
+
+Community members are expected to:
+
+- communicate with respect across differences in language, experience, and discipline;
+- give and accept specific, constructive technical or scientific feedback;
+- acknowledge uncertainty, correct mistakes, and avoid overstating evidence;
+- protect private information, credentials, and copyrighted research material;
+- focus discussion on improving the project and supporting its users.
+
+Harassment, threats, discriminatory or sexualized language, personal attacks,
+trolling, deliberate disruption, and publication of another person's private
+information without permission are unacceptable.
+
+## Scope
+
+This Code applies to repository issues, pull requests, reviews, release and
+support discussions, and other spaces operated by PaperLocale. It also applies
+when someone officially represents the project in public.
+
+## Reporting
+
+Do not put sensitive details into a public issue. Report conduct concerns
+privately through a
+[GitHub private security advisory](https://github.com/hazugi2004/paperlocale/security/advisories/new)
+and prefix the title with `[Code of Conduct]`. Reports may be written in English
+or Chinese. The core maintainer will acknowledge the report, protect the
+reporter's privacy, investigate relevant evidence, and disclose information
+only when necessary to resolve the concern.
+
+## Enforcement
+
+The maintainer may clarify expectations, request a correction or apology,
+remove harmful content, restrict participation temporarily, or ban a participant
+for severe or repeated violations. Decisions will consider context, impact,
+whether harm was repaired, and the safety of affected people. Retaliation
+against a reporter or participant in an investigation is itself a violation.
+
+## Attribution
+
+This Code is adapted from the
+[Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/),
+stewarded by the Organization for Ethical Source and licensed under
+[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 欢迎贡献解析兼容性、Provider、领域包、测试和文档。
 
+参与 Issue、PR、评审或其他项目空间即表示同意遵守
+[PaperLocale Code of Conduct](CODE_OF_CONDUCT.md)。行为问题请按其中说明私密
+报告，不要在公开 Issue 中披露个人敏感信息。
+
 提交前请：
 
 1. 不添加受版权限制的论文或译文；

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ confirm-passthrough -> translate -> validate -> render -> qa -> accept`.
 
 See the detailed [Chinese guide](README.zh-CN.md), [ROADMAP](docs/ROADMAP.md), [ARCHITECTURE](docs/ARCHITECTURE.md), [domain-pack guide](docs/DOMAIN_PACKS.zh-CN.md), [Codex for Open Source readiness](docs/CODEX_FOR_OSS_READINESS.zh-CN.md), and [PROVENANCE](docs/PROVENANCE.md).
 
+## Citation and community
+
+Research and teaching users can cite the software through
+[`CITATION.cff`](CITATION.cff); GitHub exposes the same metadata through its
+“Cite this repository” control. Participation in issues, pull requests, and
+reviews follows the [PaperLocale Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Development
 
 Unit tests do not call a model or require the layout engine:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,6 +190,12 @@ paperlocale domain-check /path/to/your-domain
 
 四个文件的原始字节与文件名共同生成内容 SHA-256；只修改内容而不提高版本号，也不会绕过运行清单的续跑身份检查。字段、门禁和贡献要求见 [领域包指南](docs/DOMAIN_PACKS.zh-CN.md)。实施进度见 [路线图](docs/ROADMAP.md)，申请证据边界见 [Codex for Open Source 准备清单](docs/CODEX_FOR_OSS_READINESS.zh-CN.md) 与 [申请草稿](docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md)，安全与订阅边界见 [安全策略](SECURITY.md)。
 
+## 引用与社区规范
+
+在研究或教学中使用本项目时，可通过 [`CITATION.cff`](CITATION.cff) 获取机器可读
+引用元数据；合并到默认分支后，GitHub 仓库侧栏也会显示 “Cite this repository”。
+参与 Issue、PR 和评审须遵守 [PaperLocale Code of Conduct](CODE_OF_CONDUCT.md)。
+
 ## 当前证据边界
 
 - 63 项单元测试不联网运行，覆盖内容合同、Provider 评估、一键断点续跑、参考文献与透传人工确认映射、碎词安全审查、领域包身份、PDF 哈希绑定、图片/矢量对象门禁、页面 QA、隔离环境入口和演示产物；

--- a/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
@@ -49,6 +49,8 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 - Initial release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.1.0
 - CI: https://github.com/hazugi2004/paperlocale/actions/workflows/tests.yml
 - Security policy: https://github.com/hazugi2004/paperlocale/security/policy
+- Code of Conduct: https://github.com/hazugi2004/paperlocale/blob/main/CODE_OF_CONDUCT.md
+- Citation metadata: https://github.com/hazugi2004/paperlocale/blob/main/CITATION.cff
 - Good first issues: https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 - Architecture: https://github.com/hazugi2004/paperlocale/blob/main/docs/ARCHITECTURE.md
 - Adoption ledger: https://github.com/hazugi2004/paperlocale/blob/main/docs/ADOPTION_EVIDENCE.zh-CN.md

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -24,6 +24,7 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 |---|---|---|
 | 明确的公共开源价值 | 学术 PDF 保版翻译、科学信息硬门禁、可扩展领域术语包 | 已实现 |
 | 核心维护者与写权限 | `MAINTAINERS.md` 与 GitHub `hazugi2004/paperlocale` 管理权限 | 已验证 |
+| 社区治理与学术引用 | Contributor Covenant 3.0 社区准则、私密行为问题报告、CFF 1.2.0 软件引用元数据 | 已实现；合并到默认分支后由 GitHub 展示 Code of Conduct 与 “Cite this repository” 入口 |
 | 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献与非正文人工确认、碎词安全审查、单向状态机、63 项不联网测试 | [PR #17](https://github.com/hazugi2004/paperlocale/pull/17)、[#18](https://github.com/hazugi2004/paperlocale/pull/18)、[#19](https://github.com/hazugi2004/paperlocale/pull/19) 的 Python 3.10–3.13 矩阵、macOS 中文/空格路径及 `[layout]` 求解均通过 |
 | 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图 | [公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)为 0 errors / 0 warnings；附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,6 +61,7 @@
 - [x] GitHub Actions
 - [x] Wheel 构建与隔离安装验证
 - [x] 贡献指南、Issue/PR 模板与标签构建工作流
+- [x] Contributor Covenant 3.0 社区准则与 `CITATION.cff` 学术引用元数据
 - [ ] 发布到 PyPI
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release


### PR DESCRIPTION
## Summary

- add a project-specific Code of Conduct adapted from Contributor Covenant 3.0
- provide a private conduct-report path without asking contributors to expose personal details in public issues
- add CFF 1.2.0 citation metadata for PaperLocale v0.3.2
- link citation and conduct guidance from both READMEs, CONTRIBUTING, roadmap, and application evidence

## Validation

- `CITATION.cff` passed `cffconvert 2.0.0 --validate` against schema 1.2.0
- generated citation: `PaperLocale contributors (2026). PaperLocale: Verified layout-preserving academic PDF translation (version 0.3.2). URL: https://github.com/hazugi2004/paperlocale`
- 63 unit tests passed
- Contributor Covenant attribution, CC BY-SA 4.0, and private-report links resolve

## Sources

- https://www.contributor-covenant.org/version/3/0/
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files
- https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md

No runtime behavior, package dependency, translation contract, or release asset changes.