### PR TITLE
docs: record community health evidence

### DIFF
--- a/docs/ADOPTION_EVIDENCE.zh-CN.md
+++ b/docs/ADOPTION_EVIDENCE.zh-CN.md
@@ -40,7 +40,7 @@ SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`�
 非维护者 `icecold009` 已公开 fork 仓库，并针对 good first issue #2 提交
 [两页 PDF QA 回归 PR #4](https://github.com/hazugi2004/paperlocale/pull/4)。维护者已在隔离工作树中将该提交与最新 `main` 组合验证，36 项测试全部通过，并公开提交批准评审和[最新主线兼容性说明](https://github.com/hazugi2004/paperlocale/pull/4#issuecomment-5330379908)；GitHub 的[首次贡献者 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)也已通过。该 PR 仍由作者标记为 Draft，尚未合并，因此它可以证明贡献入口已吸引首个外部参与者，但不能写成已采用、已发布或已合并贡献。
 
-截至目前，尚无可验证的非维护者真实翻译反馈、外部问题报告、下游引用或 PyPI 下载数据。v0.3.1 三个 Release 附件各有 1 次无法归因的下载，不能据此声称外部采用。
+截至目前，尚无可验证的非维护者真实翻译反馈、外部问题报告、下游引用或 PyPI 下载数据。v0.3.1 与 v0.3.2 各三个 Release 附件都只有维护者公开重下载复核期间产生的 1 次下载，不能据此声称外部采用。
 
 ## 记录格式
 

--- a/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
@@ -51,6 +51,7 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 - Security policy: https://github.com/hazugi2004/paperlocale/security/policy
 - Code of Conduct: https://github.com/hazugi2004/paperlocale/blob/main/CODE_OF_CONDUCT.md
 - Citation metadata: https://github.com/hazugi2004/paperlocale/blob/main/CITATION.cff
+- GitHub Community Standards (100%): https://github.com/hazugi2004/paperlocale/community
 - Good first issues: https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 - Architecture: https://github.com/hazugi2004/paperlocale/blob/main/docs/ARCHITECTURE.md
 - Adoption ledger: https://github.com/hazugi2004/paperlocale/blob/main/docs/ADOPTION_EVIDENCE.zh-CN.md

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -24,7 +24,7 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 |---|---|---|
 | 明确的公共开源价值 | 学术 PDF 保版翻译、科学信息硬门禁、可扩展领域术语包 | 已实现 |
 | 核心维护者与写权限 | `MAINTAINERS.md` 与 GitHub `hazugi2004/paperlocale` 管理权限 | 已验证 |
-| 社区治理与学术引用 | Contributor Covenant 3.0 社区准则、私密行为问题报告、CFF 1.2.0 软件引用元数据 | 已实现；合并到默认分支后由 GitHub 展示 Code of Conduct 与 “Cite this repository” 入口 |
+| 社区治理与学术引用 | Contributor Covenant 3.0 社区准则、私密行为问题报告、CFF 1.2.0 软件引用元数据 | [GitHub Community Standards](https://github.com/hazugi2004/paperlocale/community) 已验证为 100%，默认分支已识别 Code of Conduct 与 `CITATION.cff` |
 | 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献与非正文人工确认、碎词安全审查、单向状态机、63 项不联网测试 | [PR #17](https://github.com/hazugi2004/paperlocale/pull/17)、[#18](https://github.com/hazugi2004/paperlocale/pull/18)、[#19](https://github.com/hazugi2004/paperlocale/pull/19) 的 Python 3.10–3.13 矩阵、macOS 中文/空格路径及 `[layout]` 求解均通过 |
 | 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图 | [公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)为 0 errors / 0 warnings；附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |
@@ -41,7 +41,7 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 
 项目现在具备“可以公开试用和持续维护”的工程基础，并出现首个可复核的外部贡献；
 活跃维护、角色权限和生态价值已有公开证据，但仓库使用量仍弱：0 star、1 个外部
-fork、v0.3.1 三个附件各有 1 次无法归因的下载，不能视为外部采用，且没有非维护者真实翻译反馈或下游引用。因此还
+fork、v0.3.1 与 v0.3.2 各三个附件都只有维护者复核期间产生的 1 次下载，不能视为外部采用，且没有非维护者真实翻译反馈或下游引用。因此还
 不能诚实声称“广泛使用”。应推动 PR #4 完成并继续获得真实试用证据，再提交更
 有说服力的申请；如果提前申请，应明确项目尚新，并重点解释科学文献翻译的生态
 价值，不能把维护者自测、自己的 Issue 或尚未合并的 Draft PR 写成真实用户采用。


### PR DESCRIPTION
## Summary

- record the verified GitHub Community Standards score of 100%
- link the live community profile and note default-branch recognition of Code of Conduct and CITATION.cff
- preserve the adoption boundary by recording that v0.3.1/v0.3.2 asset downloads came from maintainer re-download verification

## Evidence

- https://github.com/hazugi2004/paperlocale/community
- https://github.com/hazugi2004/paperlocale/blob/main/CITATION.cff
- https://github.com/hazugi2004/paperlocale/blob/main/CODE_OF_CONDUCT.md

Documentation only; no package, workflow, release, or translation behavior changes.