### PR TITLE
ci: prepare trusted PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,123 @@
+name: publish-pypi
+
+# PyPI 发布会产生不可撤销的公开版本，因此这里只允许维护者手动触发。
+# 创建 GitHub Release 或推送标签仍由 release-build.yml 验证，但不会自动上传 PyPI。
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "已公开并通过审计的稳定 GitHub Release 标签，例如 v0.3.2"
+        required: true
+        type: string
+
+# 准备作业只需读取公开仓库；发布作业会覆盖此处权限，仅获得 OIDC 令牌权限。
+permissions:
+  contents: read
+
+jobs:
+  prepare-distributions:
+    name: Verify published distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out the exact release tag
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # 显式限定 refs/tags，避免同名分支被误当作发布来源。
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Validate tag and package metadata
+        id: metadata
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          # 所有外部输入先通过环境变量传给 Python，避免把输入拼接为 shell 代码。
+          python - <<'PY'
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          release_tag = os.environ["RELEASE_TAG"]
+          if re.fullmatch(r"v\d+\.\d+\.\d+", release_tag) is None:
+              raise SystemExit("tag 必须是稳定版本格式 vX.Y.Z")
+
+          with Path("pyproject.toml").open("rb") as stream:
+              project = tomllib.load(stream)["project"]
+          if project["name"] != "paperlocale":
+              raise SystemExit("pyproject.toml 的项目名不是 paperlocale")
+
+          version = project["version"]
+          if release_tag != f"v{version}":
+              raise SystemExit(
+                  f"标签 {release_tag} 与 pyproject.toml 版本 {version} 不一致"
+              )
+
+          # 文件名来自当前纯 Python 通用 wheel 合同；Release 缺少任一文件都会硬失败。
+          outputs = {
+              "version": version,
+              "wheel-name": f"paperlocale-{version}-py3-none-any.whl",
+              "sdist-name": f"paperlocale-{version}.tar.gz",
+          }
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              for key, value in outputs.items():
+                  stream.write(f"{key}={value}\n")
+          PY
+      - name: Download the exact GitHub Release assets
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          WHEEL_NAME: ${{ steps.metadata.outputs.wheel-name }}
+          SDIST_NAME: ${{ steps.metadata.outputs.sdist-name }}
+        run: |
+          set -euo pipefail
+          mkdir dist
+          release_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+          # 只下载标签发行中已经公开复核的两个包，避免重新构建出另一套字节。
+          curl --fail --location --retry 3 \
+            --output "dist/${WHEEL_NAME}" "${release_url}/${WHEEL_NAME}"
+          curl --fail --location --retry 3 \
+            --output "dist/${SDIST_NAME}" "${release_url}/${SDIST_NAME}"
+      - name: Validate and install the exact wheel
+        env:
+          WHEEL_PATH: dist/${{ steps.metadata.outputs.wheel-name }}
+        run: |
+          python -m pip install "twine==7.0.0"
+          python -m twine check dist/*
+          python -m pip install --force-reinstall "${WHEEL_PATH}"
+          paperlocale domain-check atmospheric-science
+          # 完整求解 layout extra，但不在发布准备作业中下载大型版面依赖。
+          python -m pip install --dry-run "${WHEEL_PATH}[layout]"
+      - name: Preserve the verified distributions for the publish job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-to-pypi:
+    name: Publish verified distributions to PyPI
+    needs: prepare-distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # 仓库中的 pypi Environment 必须配置维护者人工批准；配置步骤见项目文档。
+    environment:
+      name: pypi
+      url: https://pypi.org/p/paperlocale
+    # 本作业不检出或执行仓库代码，只获得 PyPI Trusted Publishing 所需的 OIDC 权限。
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the verified distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - 增加 Contributor Covenant 3.0 社区准则和 CFF 1.2.0 学术软件引用元数据，完善私密行为问题报告与 GitHub “Cite this repository” 入口。
+- 增加仅手动触发的 PyPI Trusted Publishing 工作流：从已审计 GitHub Release 复用确切发行包，把 OIDC 权限限制在独立发布作业，并固定关键第三方 Action 到完整提交。
 
 ## 0.3.2 - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ every candidate remains marked for manual domain review.
 ## Install
 
 Python 3.10–3.13 and Poppler's `pdftoppm` are required for the complete workflow.
+PaperLocale is not published on PyPI yet, so the verified installation path is
+currently from the repository source. The maintainer-only Trusted Publishing
+procedure is documented in [docs/PYPI_PUBLISHING.zh-CN.md](docs/PYPI_PUBLISHING.zh-CN.md).
 
 ```bash
 git clone https://github.com/hazugi2004/paperlocale.git

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,6 +55,8 @@ paperlocale provider-eval \
 ## 安装
 
 需要 Python 3.10–3.13。完整 PDF 流程还需要 Poppler 的 `pdftoppm`：macOS 可执行 `brew install poppler`，Ubuntu 可执行 `sudo apt-get install poppler-utils`。
+PaperLocale 尚未发布到 PyPI，因此当前已验证的普通用户路径仍是从仓库源码安装。仅供
+维护者使用的可信发布步骤见 [PyPI 发布手册](docs/PYPI_PUBLISHING.zh-CN.md)。
 
 ```bash
 git clone https://github.com/hazugi2004/paperlocale.git

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -29,7 +29,7 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 | 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图 | [公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)为 0 errors / 0 warnings；附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |
 | 可公开演示 | 自有合成论文的原文、译文与全页 QA GIF | 已实现 |
-| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建和上游兼容性工作流 | v0.1.0–v0.3.2；[v0.3.2 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229)验证发行元数据、确切 wheel 与 `[layout]` 求解 |
+| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建、上游兼容性工作流及受控 PyPI Trusted Publishing 工作流 | v0.1.0–v0.3.2；[v0.3.2 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229)验证发行元数据、确切 wheel 与 `[layout]` 求解；PyPI 尚未配置或发布 |
 | 公开版本 | [GitHub v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) | 已发布并设为 latest，三个附件已公开重下载复核；参考文献默认仍为 `preserve` |
 | 外部贡献 | 非维护者 fork 与 [两页 PDF QA Draft PR #4](https://github.com/hazugi2004/paperlocale/pull/4)；[贡献分支 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)及其与最新主线组合验证的 36 项测试均通过，维护者已批准 | 初步证据，等待作者标记 Ready 并合并 |
 | 广泛使用或真实用户采用 | 尚无非维护者真实翻译反馈、问题报告或下游引用 | 未证明 |

--- a/docs/PYPI_PUBLISHING.zh-CN.md
+++ b/docs/PYPI_PUBLISHING.zh-CN.md
@@ -1,0 +1,53 @@
+# PyPI 可信发布操作手册
+
+状态：工作流已准备，尚未配置 PyPI 待定发布者，也尚未向 PyPI 上传任何版本。
+
+## 设计边界
+
+`.github/workflows/publish-pypi.yml` 只接受维护者手动输入稳定标签，不响应标签推送或
+GitHub Release 事件。准备作业从对应的公开 GitHub Release 下载已经审计的 wheel 和
+sdist，复核元数据、安装入口及 `[layout]` 依赖求解；独立发布作业不检出或执行仓库
+代码，只持有 `id-token: write`，通过 PyPI Trusted Publishing 获取短期凭据。
+
+这意味着工作流合并后仍不会自行发布。PyPI 待定发布者和 GitHub Environment 都必须
+由仓库维护者本人配置，发布时还需要再次手动运行并批准 Environment。
+
+## 首次发布前一次性配置
+
+1. 在仓库 `Settings -> Environments` 新建 `pypi` Environment，将 `hazugi2004` 设为
+   required reviewer。不要在其中保存 PyPI API token。
+2. 登录 PyPI，打开 <https://pypi.org/manage/account/publishing/>，创建 pending
+   publisher，逐项填写：
+
+   | 字段 | 精确值 |
+   |---|---|
+   | PyPI Project Name | `paperlocale` |
+   | GitHub Owner | `hazugi2004` |
+   | Repository name | `paperlocale` |
+   | Workflow name | `publish-pypi.yml` |
+   | Environment name | `pypi` |
+
+3. 再次核对项目名、仓库、工作流文件名和 Environment。OIDC 声明与任一字段不一致
+   时，PyPI 会拒绝上传。
+
+2026-08-19 对 `https://pypi.org/pypi/paperlocale/json` 的只读检查返回 404，表示检查
+当时没有同名公开项目；名称只有在首次成功上传并由 PyPI 创建项目后才真正确定，不能
+把这次检查当作永久占位。
+
+## 手动发布
+
+1. 在 GitHub Actions 打开 `publish-pypi`，选择 `Run workflow`。
+2. 输入已经公开并完成审计的稳定标签，例如 `v0.3.2`。
+3. 等待 `Verify published distributions` 通过。
+4. 在 `pypi` Environment 部署审批中复核标签并手动批准。
+5. 发布作业成功后，检查 `https://pypi.org/project/paperlocale/` 的版本、文件和
+   attestations，再在全新虚拟环境执行：
+
+   ```bash
+   python -m pip install "paperlocale[layout]==0.3.2"
+   paperlocale domain-check atmospheric-science
+   ```
+
+只有上述页面和隔离安装都核验成功后，才能把 README 的普通用户安装方式改为 PyPI，
+并在路线图中勾选“发布到 PyPI”。失败时保留 Actions 日志，不使用 `skip-existing` 掩盖
+重复版本或部分上传问题。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,7 @@
 - [x] Wheel 构建与隔离安装验证
 - [x] 贡献指南、Issue/PR 模板与标签构建工作流
 - [x] Contributor Covenant 3.0 社区准则与 `CITATION.cff` 学术引用元数据
+- [x] 仅手动触发、OIDC 最小权限且复用已审计 Release 附件的 PyPI 可信发布工作流
 - [ ] 发布到 PyPI
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release

--- a/tests/test_pypi_workflow.py
+++ b/tests/test_pypi_workflow.py
@@ -1,0 +1,55 @@
+"""PyPI 发布工作流的静态安全合同。"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW_PATH = Path(__file__).parents[1] / ".github" / "workflows" / "publish-pypi.yml"
+
+
+class PyPIPublishingWorkflowTest(unittest.TestCase):
+    """防止后续维护意外绕过手动确认或扩大 OIDC 作业权限。"""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_publishing_is_manual_only(self) -> None:
+        """创建标签或 Release 不得自动触发不可撤销的 PyPI 上传。"""
+
+        trigger_block = self.workflow.split("\non:\n", 1)[1].split(
+            "\npermissions:\n", 1
+        )[0]
+        self.assertIn("workflow_dispatch:", trigger_block)
+        self.assertNotIn("push:", trigger_block)
+        self.assertNotIn("release:", trigger_block)
+
+    def test_oidc_permission_is_scoped_to_publish_job(self) -> None:
+        """只有不运行仓库 shell 代码的发布作业可以申请短期 OIDC 令牌。"""
+
+        self.assertEqual(self.workflow.count("id-token: write"), 1)
+        publish_job = self.workflow.split("\n  publish-to-pypi:\n", 1)[1]
+        self.assertIn("needs: prepare-distributions", publish_job)
+        self.assertIn("name: pypi", publish_job)
+        self.assertIn("id-token: write", publish_job)
+        self.assertNotIn("run:", publish_job)
+
+    def test_release_assets_and_actions_are_fixed(self) -> None:
+        """上传对象必须来自已审计 Release，关键第三方 Action 必须固定到提交。"""
+
+        self.assertIn("releases/download/${RELEASE_TAG}", self.workflow)
+        self.assertIn("python -m twine check dist/*", self.workflow)
+        self.assertIn(
+            "pypa/gh-action-pypi-publish@"
+            "dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
+            self.workflow,
+        )
+        self.assertNotIn("PYPI_API_TOKEN", self.workflow)
+        self.assertNotIn("password:", self.workflow)
+        self.assertNotIn("skip-existing:", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a manual-only PyPI Trusted Publishing workflow
- reuse the exact audited wheel and sdist from a stable GitHub Release
- isolate `id-token: write` to the publish job and pin third-party Actions to immutable commits
- document the pending publisher and protected `pypi` Environment setup without claiming that PyPI is already configured or published
- add static regression tests for the publishing security contract

## Verification

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v` (66 tests)
- YAML parse and `git diff --check`
- downloaded the public v0.3.2 wheel and sdist; SHA-256 matched the published evidence
- Python 3.12 isolated run: `twine check`, exact-wheel install, `domain-check atmospheric-science`, and `[layout]` dependency dry-run all passed

## Boundary

This PR does not configure a PyPI account, create a pending publisher, create/approve a GitHub Environment, dispatch the workflow, or upload a package.