### PR TITLE
docs: record verified v0.3.3 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Added
 
 - 增加 Contributor Covenant 3.0 社区准则和 CFF 1.2.0 学术软件引用元数据，完善私密行为问题报告与 GitHub “Cite this repository” 入口。
-- 增加仅手动触发的 PyPI Trusted Publishing 工作流：从已审计 GitHub Release 复用确切发行包，把 OIDC 权限限制在独立发布作业，并固定关键第三方 Action 到完整提交；[成功运行](https://github.com/hazugi2004/paperlocale/actions/runs/32441153778)已发布带 attestation 的 `v0.3.2`。
+- 增加仅手动触发的 PyPI Trusted Publishing 工作流：从已审计 GitHub Release 复用确切发行包，把 OIDC 权限限制在独立发布作业，并固定关键第三方 Action 到完整提交；[首次成功运行](https://github.com/hazugi2004/paperlocale/actions/runs/32441153778)发布 `v0.3.2`，[后续运行](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459)发布 `v0.3.3`，两次均生成公开 attestation。
 - 合并首个非维护者贡献 [PR #4](https://github.com/hazugi2004/paperlocale/pull/4)，将项目自有 PDF QA 合成夹具扩展为两页并增加第二页占位符回归。
 - 增加 `apply-text-repair` 受控文字修复：显式绑定页码、矩形、替换文字、字体和字号，保留页结构、图片、链接、既有矢量与矩形外正文，只为本次替换独立生成字体子集，并记录修复前后文字、字体/PDF 哈希、备份及 QA 重置。
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ every candidate remains marked for manual domain review.
 ## Install
 
 Python 3.10–3.13 and Poppler's `pdftoppm` are required for the complete workflow.
-PaperLocale 0.3.2 is published on PyPI through attested Trusted Publishing.
+PaperLocale 0.3.3 is published on PyPI through attested Trusted Publishing.
 The audited maintainer procedure and release evidence are documented in
 [docs/PYPI_PUBLISHING.zh-CN.md](docs/PYPI_PUBLISHING.zh-CN.md).
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install "paperlocale[layout]==0.3.2"
+python -m pip install "paperlocale[layout]==0.3.3"
 paperlocale domain-check atmospheric-science
 ```
 
@@ -252,7 +252,7 @@ the newest `pdf2zh-next` release allowed by the declared dependency range.
 
 ## Contributing
 
-Start with the scoped [good first issues](https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), or read [CONTRIBUTING.md](CONTRIBUTING.md). Current entry points cover an ecology domain pack, a two-page synthetic PDF regression, and Ubuntu installation verification.
+Start with the scoped [good first issues](https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), or read [CONTRIBUTING.md](CONTRIBUTING.md). Current entry points cover an ecology domain pack, Ubuntu installation verification, and independent review of the atmospheric-science Provider evaluation.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,13 +55,13 @@ paperlocale provider-eval \
 ## 安装
 
 需要 Python 3.10–3.13。完整 PDF 流程还需要 Poppler 的 `pdftoppm`：macOS 可执行 `brew install poppler`，Ubuntu 可执行 `sudo apt-get install poppler-utils`。
-PaperLocale 0.3.2 已通过带数字 attestation 的 Trusted Publishing 发布到 PyPI；
+PaperLocale 0.3.3 已通过带数字 attestation 的 Trusted Publishing 发布到 PyPI；
 维护者发布流程与公开核验证据见 [PyPI 发布手册](docs/PYPI_PUBLISHING.zh-CN.md)。
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install "paperlocale[layout]==0.3.2"
+python -m pip install "paperlocale[layout]==0.3.3"
 paperlocale domain-check atmospheric-science
 ```
 
@@ -220,9 +220,10 @@ paperlocale domain-check /path/to/your-domain
 
 ## 当前证据边界
 
-- 63 项单元测试不联网运行，覆盖内容合同、Provider 评估、一键断点续跑、参考文献与透传人工确认映射、碎词安全审查、领域包身份、PDF 哈希绑定、图片/矢量对象门禁、页面 QA、隔离环境入口和演示产物；
+- 74 项单元测试不联网运行，覆盖内容合同、Provider 评估、一键断点续跑、参考文献与透传人工确认映射、碎词安全审查、领域包身份、PDF 哈希绑定、图片/矢量对象门禁、受控文字修复、页面 QA、隔离环境入口和演示产物；
 - 本地已用 `pdf2zh-next 2.9.0` 跑通合成 A4 双栏 PDF 的收集、查表重建和逐页 QA；
-- 合成页包含公式占位、矢量表格与嵌入图片；最新 QA 报告中源文/译文均为 1 个图片对象和 8 次矢量绘制，不提交任何受版权限制的论文；
+- 版面兼容性夹具包含公式占位、矢量表格与嵌入图片；源文/译文均为 1 个图片对象和 8 次矢量绘制；
+- v0.3.3 两页中文文字修复夹具将 23,278,008 字节原始字体独立子集化为 22,912 字节，最终 PDF 为 19,594 字节；机器 QA 为 0 errors / 0 warnings，并已逐页视觉验收。两类夹具均为项目自有，不提交任何受版权限制的论文；
 - “保版”不等于像素完全一致。中文长度变化会改变行内断行，因此最终候选必须人工逐页核对。
 
 ## 开发与版面兼容性检查
@@ -248,4 +249,4 @@ python scripts/layout_smoke.py \
 
 ## 参与贡献
 
-可以从已有的 [good first issues](https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 开始，或阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。当前入口包括生态学领域包、两页合成 PDF 回归和 Ubuntu 安装复核。
+可以从已有的 [good first issues](https://github.com/hazugi2004/paperlocale/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) 开始，或阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。当前入口包括生态学领域包、Ubuntu 安装复核和大气科学 Provider 评估独立复核。

--- a/docs/ADOPTION_EVIDENCE.zh-CN.md
+++ b/docs/ADOPTION_EVIDENCE.zh-CN.md
@@ -28,6 +28,15 @@
 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`。
 真实论文及完整译本未上传或分发；该证据仍是维护者测试，不是外部用户采用。
 
+[v0.3.3](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3) 把真实论文视觉
+验收中暴露的文字碎裂修复正式化为受控 `apply-text-repair`：显式限定页码、矩形、
+替换文字、字体与字号，保留备份、修复历史和哈希绑定，并为每次修复生成独立字体
+子集。[实现 PR #27](https://github.com/hazugi2004/paperlocale/pull/27) 与
+[标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32444041611)通过 74 项
+测试及 Python 3.10–3.13 矩阵。项目自有两页中文修复夹具机器 QA 为 0 errors /
+0 warnings，已逐页视觉验收；原始 23,278,008 字节字体子集为 22,912 字节，最终 PDF
+为 19,594 字节。该夹具不分发真实论文，仍属于维护者工程证据，不是外部采用。
+
 维护者于 2026-08-21 使用受保护的 GitHub Environment 和 PyPI Trusted Publishing
 发布 [PyPI v0.3.2](https://pypi.org/project/paperlocale/0.3.2/)。
 [第一次运行](https://github.com/hazugi2004/paperlocale/actions/runs/32239980222)
@@ -36,6 +45,15 @@ SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7`�
 Release 的确切 wheel/sdist，并为两个文件生成绑定本仓库工作流的数字 attestation。
 维护者完成哈希、密码学验证、隔离安装和 `[layout]` 求解；这些证明可审计分发能力，
 仍不是非维护者采用或下载证据。
+
+同日，[PyPI v0.3.3](https://pypi.org/project/paperlocale/0.3.3/) 由
+[后续 Trusted Publishing 运行](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459)
+从确切 GitHub Release 附件发布。GitHub 与 PyPI 的 wheel SHA-256 均为
+`9738ff9a515f10c1da9a10852fbfc3c9d44a4d1febfe233df173a2be8edaeaab`，sdist 均为
+`c35d9e4a16ea1af5cb8c03c4bea30a1f9fee0f379e920eee155215f5e8138198`；两个 PyPI
+provenance 绑定仓库、工作流和 `pypi` Environment，并通过 `pypi-attestations`
+密码学验证。全新 Python 3.12 环境的确切安装、`pip check`、领域包检查、文字修复
+入口与 `[layout]` 求解均通过。以上仍是维护者发布核验，不代表非维护者安装或使用。
 
 维护者还在 PDFMathTranslate-next 上游发布了
 [CLITranslator 两阶段集成讨论 #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)，并在 v0.2.0 发布后补充了[真实兼容性与标签构建证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545)。它证明上游沟通和可复现跟进已经开始；在上游维护者或其他参与者回复前，它仍不构成外部认可或采用。
@@ -56,9 +74,8 @@ Release 的确切 wheel/sdist，并为两个文件生成绑定本仓库工作流
 单独证明真实论文翻译采用、外部下载或广泛使用。
 
 截至目前，尚无可验证的非维护者真实翻译反馈、外部问题报告、下游引用或 PyPI
-外部下载证据。v0.3.1 与 v0.3.2 各三个 GitHub Release 附件都只有维护者公开重下载
-复核期间产生的 1 次下载；PyPI 首发后的下载与安装也来自本次维护者核验，不能据此
-声称外部采用。
+外部下载证据。现有 GitHub Release 与 PyPI 安装核验均由维护者执行，不能据此声称
+外部采用。
 
 ## 记录格式
 
@@ -72,6 +89,8 @@ Release 的确切 wheel/sdist，并为两个文件生成绑定本仓库工作流
 | 2026-08-19 | 维护者兼容性热修复 | [v0.3.1](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.1) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32221420406) / [标签兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32221715819) / [永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.1/paperlocale-v0.3.1-layout-compatibility.zip) | 公开保留失败证据后修复 `[layout]` 安装；54 项测试、确切 wheel 依赖求解、真实版面 QA 0 错误、附件哈希复核 | 否 |
 | 2026-08-19 | 功能 Release | [v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229) / [兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256) / [永久附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip) | 第二次真实试运行反向校准、schema 4、人工透传、碎词安全审查、63 项测试与公开附件哈希 | 否 |
 | 2026-08-21 | PyPI Trusted Publishing | [PyPI 0.3.2](https://pypi.org/project/paperlocale/0.3.2/) / [成功运行](https://github.com/hazugi2004/paperlocale/actions/runs/32441153778) | 精确 GitHub Release 附件、OIDC 最小权限、数字 attestation、哈希与隔离安装证据；不证明外部采用 | 否 |
+| 2026-08-21 | 功能 Release | [v0.3.3](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3) / [PR #27](https://github.com/hazugi2004/paperlocale/pull/27) / [构建](https://github.com/hazugi2004/paperlocale/actions/runs/32444041611) | 受控文字修复、独立字体子集、74 项测试与两页中文夹具视觉验收；不证明外部采用 | 否 |
+| 2026-08-21 | PyPI Trusted Publishing | [PyPI 0.3.3](https://pypi.org/project/paperlocale/0.3.3/) / [成功运行](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459) | 精确 GitHub Release 附件、数字 attestation、哈希、密码学验证与隔离安装证据；不证明外部采用 | 否 |
 | 2026-08-18 | 维护者发起的上游讨论 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354) | 两阶段 CLITranslator 接口稳定性与文档协作请求 | 否，等待外部回复 |
 | 2026-08-19 | 维护者上游跟进 | [v0.2.0 兼容性证据](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354#issuecomment-5330814545) | 真实兼容性运行、标签构建和结构 QA 证据 | 否，等待外部回复 |
 | 2026-08-19 | 维护者上游修复 | [BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) / [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 同文返回保持原版面对象的最小修复和回归测试；三条自动审查意见已处理 | 否，等待上游维护者审查 |

--- a/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_APPLICATION_DRAFT.zh-CN.md
@@ -14,7 +14,7 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 - Project: PaperLocale
 - Repository: https://github.com/hazugi2004/paperlocale
 - Core maintainer: `hazugi2004`
-- Role evidence: 仓库管理员、提交者和 `v0.1.0` / `v0.1.1` / `v0.2.0` / `v0.3.0` / `v0.3.1` / `v0.3.2` 发布者
+- Role evidence: 仓库管理员、提交者和 `v0.1.0` / `v0.1.1` / `v0.2.0` / `v0.3.0` / `v0.3.1` / `v0.3.2` / `v0.3.3` 发布者
 - License: AGPL-3.0-only
 
 ## 英文项目简介
@@ -31,9 +31,12 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 
 ## 已有证据链接
 
-- Latest release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2
-- PyPI distribution: https://pypi.org/project/paperlocale/0.3.2/
-- Attested PyPI publish: https://github.com/hazugi2004/paperlocale/actions/runs/32441153778
+- Latest release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3
+- PyPI distribution: https://pypi.org/project/paperlocale/0.3.3/
+- Attested PyPI publish: https://github.com/hazugi2004/paperlocale/actions/runs/32445150459
+- v0.3.3 release build: https://github.com/hazugi2004/paperlocale/actions/runs/32444041611
+- v0.3.3 controlled text-repair PR: https://github.com/hazugi2004/paperlocale/pull/27
+- v0.3.3 release evidence: https://github.com/hazugi2004/paperlocale/blob/main/docs/releases/v0.3.3.md
 - v0.3.2 release build: https://github.com/hazugi2004/paperlocale/actions/runs/32234314229
 - v0.3.2 layout compatibility run: https://github.com/hazugi2004/paperlocale/actions/runs/32234356256
 - Durable v0.3.2 compatibility artifact: https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip
@@ -63,8 +66,9 @@ API Key、登录凭据、未公开论文或其他机密信息。申请和提交�
 
 ## 提交前仍需补强
 
-项目已发布六个 GitHub 版本，并把 v0.3.2 通过带数字 attestation 的 Trusted
-Publishing 发布到 PyPI；首个非维护者贡献 PR #4 也已通过评审、测试并合并。它证明
+项目已发布七个 GitHub 版本，并把 v0.3.2 与当前最新版 v0.3.3 通过带数字
+attestation 的 Trusted Publishing 发布到 PyPI；首个非维护者贡献 PR #4 也已通过
+评审、测试并合并。它证明
 贡献入口有效，但仍不能代替真实使用。以下再完成至少一类独立证据后，申请说服力
 会显著提高：
 

--- a/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
+++ b/docs/CODEX_FOR_OSS_READINESS.zh-CN.md
@@ -25,12 +25,12 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 | 明确的公共开源价值 | 学术 PDF 保版翻译、科学信息硬门禁、可扩展领域术语包 | 已实现 |
 | 核心维护者与写权限 | `MAINTAINERS.md` 与 GitHub `hazugi2004/paperlocale` 管理权限 | 已验证 |
 | 社区治理与学术引用 | Contributor Covenant 3.0 社区准则、私密行为问题报告、CFF 1.2.0 软件引用元数据 | [GitHub Community Standards](https://github.com/hazugi2004/paperlocale/community) 已验证为 100%，默认分支已识别 Code of Conduct 与 `CITATION.cff` |
-| 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献与非正文人工确认、碎词安全审查、单向状态机、当前主线 67 项不联网测试 | [PR #17](https://github.com/hazugi2004/paperlocale/pull/17)、[#18](https://github.com/hazugi2004/paperlocale/pull/18)、[#19](https://github.com/hazugi2004/paperlocale/pull/19) 的 Python 3.10–3.13 矩阵、macOS 中文/空格路径及 `[layout]` 求解均通过 |
-| 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图 | [公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)为 0 errors / 0 warnings；附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
+| 可运行项目 | 一键断点续跑 CLI、两种 Provider、Provider 评估、参考文献与非正文人工确认、碎词安全审查、受控文字修复、单向状态机、当前主线 74 项不联网测试 | [v0.3.3 实现 PR #27](https://github.com/hazugi2004/paperlocale/pull/27)及 Python 3.10–3.13 矩阵通过；macOS 中文/空格路径与 `[layout]` 求解继续受 CI 保护 |
+| 可复现质量证据 | 合成双栏 PDF、公式合同、人工透传与碎词安全清单、图片与矢量绘图硬门禁、逐页 QA；[v0.3.2 永久审计附件](https://github.com/hazugi2004/paperlocale/releases/download/v0.3.2/paperlocale-v0.3.2-layout-compatibility.zip)保留日志、映射、清单与对照图；v0.3.3 两页中文修复夹具完成独立字体子集、0 errors / 0 warnings 和逐页视觉验收 | [v0.3.2 公开兼容性运行](https://github.com/hazugi2004/paperlocale/actions/runs/32234356256)及 [v0.3.3 发布说明](https://github.com/hazugi2004/paperlocale/blob/main/docs/releases/v0.3.3.md)；兼容性附件 SHA-256 为 `3f50a2a3adfe5b66d037cb905827b0d8c5ba9d6bc9307908223b77628ec61dc7` |
 | 翻译质量证据 | `codex-local` 对大气科学包 5/5 内容合同通过；候选、参考、[逐条复核工作表](evidence/codex-local-atmospheric-science-review.zh-CN.md)与 [Issue #5](https://github.com/hazugi2004/paperlocale/issues/5) 公开 | 初步证据，等待非维护者领域人员提交复核 |
 | 可公开演示 | 自有合成论文的原文、译文与全页 QA GIF | 已实现 |
-| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建、上游兼容性工作流及受控 PyPI Trusted Publishing 工作流 | [v0.3.2 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32234314229)验证发行元数据；[PyPI 发布](https://github.com/hazugi2004/paperlocale/actions/runs/32441153778)复用确切附件并生成数字 attestation，隔离安装与 `[layout]` 求解通过 |
-| 公开版本 | [GitHub v0.3.2](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.2) / [PyPI 0.3.2](https://pypi.org/project/paperlocale/0.3.2/) | GitHub latest 与 PyPI 均已发布；两处 wheel/sdist SHA-256 一致，PyPI provenance 绑定本仓库工作流；参考文献默认仍为 `preserve` |
+| 发布与维护机制 | CHANGELOG、安全策略、Issue/PR 模板、测试、标签构建、上游兼容性工作流及受控 PyPI Trusted Publishing 工作流 | [v0.3.3 标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32444041611)验证发行元数据；[PyPI 发布](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459)复用确切附件并生成数字 attestation，隔离安装与 `[layout]` 求解通过 |
+| 公开版本 | [GitHub v0.3.3](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3) / [PyPI 0.3.3](https://pypi.org/project/paperlocale/0.3.3/) | GitHub latest 与 PyPI 均已发布；两处 wheel/sdist SHA-256 一致，PyPI provenance 绑定本仓库工作流并通过 `pypi-attestations` 验证；参考文献默认仍为 `preserve` |
 | 外部贡献 | 非维护者 fork 与 [两页 PDF QA PR #4](https://github.com/hazugi2004/paperlocale/pull/4)；[贡献分支 CI](https://github.com/hazugi2004/paperlocale/actions/runs/32150697274)及其与最新主线组合验证的 67 项测试均通过，维护者已批准 | 已于 2026-08-21 以[提交 `9460265`](https://github.com/hazugi2004/paperlocale/commit/9460265766d4ceda32a3a294ec7fe56cf18677ad)合并，成为首个非维护者合并贡献 |
 | 广泛使用或真实用户采用 | 尚无非维护者真实翻译反馈、问题报告或下游引用 | 未证明 |
 | 上游生态协作 | [PDFMathTranslate-next #354](https://github.com/PDFMathTranslate-next/PDFMathTranslate-next/issues/354)、[BabelDOC #610](https://github.com/funstory-ai/BabelDOC/issues/610) 与最小修复及回归测试 [PR #611](https://github.com/funstory-ai/BabelDOC/pull/611) | 三条自动审查意见均已处理，最新为[提交 `be8b888`](https://github.com/hazugi2004/BabelDOC/commit/be8b88895f1e432d6bdaa97d3192d874f6f67732)；尚无上游维护者回应或合并，首次 fork Actions 等待批准运行 |
@@ -40,10 +40,10 @@ OpenAI 决定；申请不保证入选。评估可考虑仓库使用情况、生�
 ## 申请判断
 
 项目现在具备“可以公开试用和持续维护”的工程基础，并已合并首个可复核的外部贡献；
-活跃维护、角色权限和生态价值已有公开证据，但仓库使用量仍弱：0 star、1 个外部
-fork、v0.3.1 与 v0.3.2 各三个 GitHub 附件都只有维护者复核期间产生的 1 次下载；
-PyPI 首次发布后的 attestation 与隔离安装也都是维护者核验，不能视为外部采用，
-且没有非维护者真实翻译反馈或下游引用。因此还
+活跃维护、角色权限和生态价值已有公开证据，但仓库使用量仍弱：核验时为 0 star、
+1 个外部 fork。v0.3.3 的 GitHub/PyPI 发布、attestation、隔离安装和合成夹具视觉验收
+也都由维护者执行，只能证明发行完整性，不能视为外部采用；目前仍没有非维护者真实
+翻译反馈或下游引用。因此还
 不能诚实声称“广泛使用”。应继续获得真实试用或下游引用证据，再提交更
 有说服力的申请；如果提前申请，应明确项目尚新，并重点解释科学文献翻译的生态
 价值，不能把维护者自测、自己的 Issue 或单个已合并测试 PR 写成真实用户采用。

--- a/docs/COMMUNITY_OUTREACH_DRAFTS.zh-CN.md
+++ b/docs/COMMUNITY_OUTREACH_DRAFTS.zh-CN.md
@@ -47,7 +47,7 @@
 >
 > 重点保护公式占位符、富文本标签、数字、单位、缩写、URL、DOI 和固定专业术语；源 PDF、候选 PDF 与 QA 报告通过 SHA-256 绑定。候选文件在 QA 后被替换时，验收会直接失败。
 >
-> 当前版本为 v0.3.2，已有 63 项测试覆盖 Python 3.10–3.13，并提供断点续跑、参考文献与非正文人工确认、跨对象碎词安全审查、真实 Provider 领域案例评估和逐页机器 QA；图片或矢量绘图少于原文时 QA 会失败并红框定位。v0.3.2 的自有合成 PDF 已跑通安全确认、翻译、重建和 QA，覆盖双栏、公式、矢量表格和嵌入图片。项目不会分发受版权限制的论文或完整译本。
+> 当前版本为 v0.3.3，已有 74 项测试覆盖 Python 3.10–3.13，并提供断点续跑、参考文献与非正文人工确认、跨对象碎词安全审查、真实 Provider 领域案例评估、受控文字修复和逐页机器 QA；图片或矢量绘图少于原文时 QA 会失败并红框定位。自有合成 PDF 已跑通安全确认、翻译、重建和 QA，覆盖双栏、公式、矢量表格和嵌入图片；两页中文文字修复夹具也完成 0 errors / 0 warnings 与逐页视觉验收。项目不会分发受版权限制的论文或完整译本。
 >
 > 目前最需要的不是单纯 Star，而是实际试用反馈、Linux 安装复核、新领域术语包和可复现的版面问题。仓库中已经准备了 3 个 good first issues。
 
@@ -57,7 +57,7 @@
 >
 > It supports an authenticated local Codex session and BYOK OpenAI-compatible endpoints, while enforcing hard gates for formulas, style placeholders, numbers, units, abbreviations, URLs, DOIs, and domain terminology. The source PDF, rendered candidate, and QA report are SHA-256 bound, and every page must be reviewed before acceptance.
 >
-> v0.3.2 has 63 model-free tests across Python 3.10–3.13, resumable translation, hash-bound reference and non-translatable-segment confirmation, split-token safety review, reproducible Provider evaluation, vector-loss localization, and a synthetic PDF smoke path covering two columns, formulas, a vector table, and an embedded image. No copyrighted research paper or full translation is distributed.
+> v0.3.3 has 74 model-free tests across Python 3.10–3.13, resumable translation, hash-bound reference and non-translatable-segment confirmation, split-token safety review, reproducible Provider evaluation, vector-loss localization, audited text repair, and synthetic PDF paths covering two columns, formulas, a vector table, an embedded image, and a two-page Chinese repair fixture. No copyrighted research paper or full translation is distributed.
 >
 > I am looking for reproducible feedback, Linux installation verification, and contributors for additional scientific domain packs. Three scoped good first issues are open.
 

--- a/docs/PYPI_PUBLISHING.zh-CN.md
+++ b/docs/PYPI_PUBLISHING.zh-CN.md
@@ -1,7 +1,8 @@
 # PyPI 可信发布操作手册
 
-状态：`v0.3.2` 已于 2026-08-21 通过 PyPI Trusted Publishing 发布并完成公开
-attestation、哈希、隔离安装和 `[layout]` 依赖求解核验。
+状态：`v0.3.2` 与 `v0.3.3` 已于 2026-08-21 通过 PyPI Trusted Publishing 发布；
+当前最新版 `v0.3.3` 已完成公开 attestation、哈希、隔离安装和 `[layout]` 依赖求解
+核验。
 
 ## 设计边界
 
@@ -51,11 +52,31 @@ publisher；任一字段不一致都会被 PyPI 拒绝。
 - 全新 Python 3.12 环境从 `https://pypi.org/simple` 安装确切 0.3.2，`pip check`、
   `paperlocale domain-check atmospheric-science` 和 `[layout]` dry-run 求解全部通过。
 
-## 后续手动发布
+## v0.3.3 后续发布证据
+
+`v0.3.3` 的后续发布证明同一可信发布路径可以复用，而不是只在首次创建 PyPI 项目时
+偶然成功：
+
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32444041611)
+  从提交 `6002805` 构建并安装确切 wheel，`twine check` 与 `[layout]` 求解通过；
+- [GitHub v0.3.3 Release](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3)
+  的 wheel SHA-256 为
+  `9738ff9a515f10c1da9a10852fbfc3c9d44a4d1febfe233df173a2be8edaeaab`，
+  sdist 为
+  `c35d9e4a16ea1af5cb8c03c4bea30a1f9fee0f379e920eee155215f5e8138198`；
+- [PyPI 发布运行](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459)
+  的准备和发布作业均成功，PyPI 两个文件与 GitHub Release 哈希完全一致；
+- 两个 PyPI Integrity API provenance 均绑定 GitHub 仓库 `hazugi2004/paperlocale`、
+  工作流 `publish-pypi.yml` 和 Environment `pypi`；
+  `pypi-attestations==0.0.30` 对 wheel 与 sdist 的密码学验证均返回 `OK`；
+- 全新 Python 3.12 环境从 PyPI 安装确切 0.3.3 后，模块版本、发行版本、`pip check`、
+  `domain-check`、`apply-text-repair` 入口和 `[layout]` dry-run 求解全部通过。
+
+## 后续版本操作
 
 1. 在 GitHub Actions 打开 `publish-pypi`，选择 `Run workflow`。
-2. 输入已经公开并完成审计、且尚未上传 PyPI 的稳定标签，例如 `v0.3.3`；PyPI
-   版本不可覆盖，不要再次发布 `v0.3.2`。
+2. 输入已经公开并完成审计、且尚未上传 PyPI 的稳定标签，例如未来的 `v0.3.4`；
+   PyPI 版本不可覆盖，不要再次发布 `v0.3.2` 或 `v0.3.3`。
 3. 等待 `Verify published distributions` 通过。
 4. 在 `pypi` Environment 部署审批中复核标签并手动批准。
 5. 发布作业成功后，检查 `https://pypi.org/project/paperlocale/` 的版本、文件和

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,12 +64,13 @@
 - [x] 贡献指南、Issue/PR 模板与标签构建工作流
 - [x] Contributor Covenant 3.0 社区准则与 `CITATION.cff` 学术引用元数据
 - [x] 仅手动触发、OIDC 最小权限且复用已审计 Release 附件的 PyPI 可信发布工作流
-- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2`
+- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2` 和 `v0.3.3`
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release
 - [x] GitHub `v0.3.0` 真实试运行反向校准、参考文献审计与恢复语义 Release
 - [x] GitHub `v0.3.1` 版面依赖兼容性热修复与确切 wheel `[layout]` 求解验证
 - [x] GitHub `v0.3.2` 行号参考文献、人工透传、碎词安全审查与 schema 4 Release
+- [x] GitHub `v0.3.3` 受控文字修复、独立字体子集与 74 项测试 Release
 - [x] 三个有验收标准的 good first issues
 - [x] 自有合成论文的原文、译文与全页 QA 演示 GIF
 

--- a/docs/releases/v0.3.3.md
+++ b/docs/releases/v0.3.3.md
@@ -38,6 +38,24 @@ v0.3.3 为真实论文视觉验收中无法在片段层修复的文字碎裂提�
 - 从源码构建的 wheel 在全新虚拟环境完成依赖安装、`pip check`、领域包检查及
   `apply-text-repair` 入口发现，发行元数据包含 `fonttools>=4.55`。
 
+## 公开发行
+
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32444041611)
+  成功，[GitHub v0.3.3](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3)
+  已设为 latest；
+- wheel SHA-256 为
+  `9738ff9a515f10c1da9a10852fbfc3c9d44a4d1febfe233df173a2be8edaeaab`，
+  sdist 为
+  `c35d9e4a16ea1af5cb8c03c4bea30a1f9fee0f379e920eee155215f5e8138198`；
+- [PyPI 0.3.3](https://pypi.org/project/paperlocale/0.3.3/) 由
+  [受保护的 Trusted Publishing 运行](https://github.com/hazugi2004/paperlocale/actions/runs/32445150459)
+  从上述确切 GitHub Release 附件发布；两处文件哈希完全一致；
+- PyPI Integrity API 的 wheel 与 sdist provenance 都绑定仓库
+  `hazugi2004/paperlocale`、工作流 `publish-pypi.yml` 和 Environment `pypi`；
+  `pypi-attestations==0.0.30` 密码学验证均返回 `OK`；
+- 全新 Python 3.12 环境从 PyPI 安装确切 0.3.3，模块/发行版本、`pip check`、
+  `domain-check`、`apply-text-repair` 入口及 `[layout]` dry-run 求解全部通过。
+
 上述合成 PDF 和字体只用于本地发布前验收，未作为发行附件上传。真实论文及完整译本
 继续不上传、不重新分发；用户提供的字体必须在本机合法取得。参考文献默认策略仍为
 `preserve`，本版本没有改变该默认值。


### PR DESCRIPTION
## Summary

- update English and Chinese installation examples to the attested PyPI `0.3.3` release
- record exact GitHub/PyPI distribution hashes, provenance identity, cryptographic attestation verification, and fresh-install checks
- add v0.3.3 controlled text-repair and synthetic visual-QA evidence to the roadmap, release notes, and Codex for Open Source materials
- keep maintainer-run publication checks explicitly separate from external adoption evidence
- refresh the remaining good-first-issue entry points

## Verification

- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -v` — 74/74 passed
- `git diff --check` — passed
- stale-current-version wording scan — no remaining v0.3.2 current-version claims

## Publication evidence

- GitHub Release: https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.3
- PyPI: https://pypi.org/project/paperlocale/0.3.3/
- release build: https://github.com/hazugi2004/paperlocale/actions/runs/32444041611
- Trusted Publishing: https://github.com/hazugi2004/paperlocale/actions/runs/32445150459