### PR TITLE
Document verified v0.3.4 publication

### DIFF
--- a/docs/PYPI_PUBLISHING.zh-CN.md
+++ b/docs/PYPI_PUBLISHING.zh-CN.md
@@ -1,7 +1,7 @@
 # PyPI 可信发布操作手册
 
-状态：`v0.3.2` 与 `v0.3.3` 已于 2026-08-21 通过 PyPI Trusted Publishing 发布；
-当前最新版 `v0.3.3` 已完成公开 attestation、哈希、隔离安装和 `[layout]` 依赖求解
+状态：`v0.3.2`、`v0.3.3` 与 `v0.3.4` 已通过 PyPI Trusted Publishing 发布；
+当前最新版 `v0.3.4` 已完成公开 attestation、哈希、隔离安装和 `[layout]` 依赖求解
 核验。
 
 ## 设计边界
@@ -72,11 +72,29 @@ publisher；任一字段不一致都会被 PyPI 拒绝。
 - 全新 Python 3.12 环境从 PyPI 安装确切 0.3.3 后，模块版本、发行版本、`pip check`、
   `domain-check`、`apply-text-repair` 入口和 `[layout]` dry-run 求解全部通过。
 
+## v0.3.4 后续发布证据
+
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32626353951)
+  从合并提交 `bcb82e9` 构建并安装确切 wheel，版本一致性、`twine check`、
+  领域包和 `[layout]` 求解全部通过；
+- [GitHub v0.3.4 Release](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.4)
+  的 wheel SHA-256 为
+  `2d40688f2f1d1cf5ae130b33342dcadc987cb2945f8fa9220a85332df94fdc97`，
+  sdist 为
+  `0571ec37e452f2389f0303d5a3289f8ee670c5b70b7254ac85de629b31e0641e`；
+- [PyPI 发布运行](https://github.com/hazugi2004/paperlocale/actions/runs/32626495081)
+  的准备和发布作业均成功，PyPI 两个文件与 GitHub Release 哈希完全一致；
+- 两个 PyPI provenance 均绑定仓库 `hazugi2004/paperlocale`、工作流
+  `publish-pypi.yml` 和 Environment `pypi`；`pypi-attestations==0.0.30`
+  验证 wheel 和 sdist 均返回 `OK`；
+- 全新 Python 3.12 环境从 PyPI 禁用缓存安装确切 0.3.4 后，模块/发行/CLI
+  版本、`pip check`、Qwen-MT Provider 导入和 `domain-check` 全部通过。
+
 ## 后续版本操作
 
 1. 在 GitHub Actions 打开 `publish-pypi`，选择 `Run workflow`。
-2. 输入已经公开并完成审计、且尚未上传 PyPI 的稳定标签，例如未来的 `v0.3.4`；
-   PyPI 版本不可覆盖，不要再次发布 `v0.3.2` 或 `v0.3.3`。
+2. 输入已经公开并完成审计、且尚未上传 PyPI 的稳定标签；PyPI 版本不可覆盖，
+   不要再次发布 `v0.3.2`、`v0.3.3` 或 `v0.3.4`。
 3. 等待 `Verify published distributions` 通过。
 4. 在 `pypi` Environment 部署审批中复核标签并手动批准。
 5. 发布作业成功后，检查 `https://pypi.org/project/paperlocale/` 的版本、文件和

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,13 +65,14 @@
 - [x] 贡献指南、Issue/PR 模板与标签构建工作流
 - [x] Contributor Covenant 3.0 社区准则与 `CITATION.cff` 学术引用元数据
 - [x] 仅手动触发、OIDC 最小权限且复用已审计 Release 附件的 PyPI 可信发布工作流
-- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2` 和 `v0.3.3`
+- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2`、`v0.3.3` 和 `v0.3.4`
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release
 - [x] GitHub `v0.3.0` 真实试运行反向校准、参考文献审计与恢复语义 Release
 - [x] GitHub `v0.3.1` 版面依赖兼容性热修复与确切 wheel `[layout]` 求解验证
 - [x] GitHub `v0.3.2` 行号参考文献、人工透传、碎词安全审查与 schema 4 Release
 - [x] GitHub `v0.3.3` 受控文字修复、独立字体子集与 74 项测试 Release
+- [x] GitHub `v0.3.4` Qwen-MT 泛化、单片段检查点、参考文献行识别与 88 项测试 Release
 - [x] 三个有验收标准的 good first issues
 - [x] 自有合成论文的原文、译文与全页 QA 演示 GIF
 

--- a/docs/releases/v0.3.4.md
+++ b/docs/releases/v0.3.4.md
@@ -45,3 +45,26 @@ v0.3.4 把第三个真实翻译 Provider `qwen-mt` 正式纳入公共流水线�
 
 真实论文、完整译本、本地运行目录和 API 凭据均未纳入仓库或发行包。
 参考文献默认策略仍为 `preserve`，机器 QA 后仍必须逐页人工验收。
+
+## 公开发行
+
+- [实现 PR #30](https://github.com/hazugi2004/paperlocale/pull/30) 的 Python
+  3.10–3.13、macOS 非 editable 中文/空格路径和 `[layout]` 求解通过；
+  [合并后主线运行](https://github.com/hazugi2004/paperlocale/actions/runs/32626292649)
+  亦全部成功；
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32626353951)
+  成功，[GitHub v0.3.4](https://github.com/hazugi2004/paperlocale/releases/tag/v0.3.4)
+  已设为 latest；
+- wheel SHA-256 为
+  `2d40688f2f1d1cf5ae130b33342dcadc987cb2945f8fa9220a85332df94fdc97`，
+  sdist 为
+  `0571ec37e452f2389f0303d5a3289f8ee670c5b70b7254ac85de629b31e0641e`；
+- [PyPI 0.3.4](https://pypi.org/project/paperlocale/0.3.4/) 由
+  [Trusted Publishing 运行](https://github.com/hazugi2004/paperlocale/actions/runs/32626495081)
+  从上述确切 GitHub Release 附件发布，两处文件哈希完全一致；
+- PyPI Integrity API 的 wheel 与 sdist provenance 均绑定仓库
+  `hazugi2004/paperlocale`、工作流 `publish-pypi.yml`和 Environment `pypi`；
+  `pypi-attestations==0.0.30` 密码学验证均返回 `OK`；
+- 全新 Python 3.12 环境禁用 pip 缓存后从 PyPI 安装确切 0.3.4，
+  模块/发行/CLI 版本、`pip check`、Qwen-MT Provider 导入和
+  `domain-check` 全部通过。


### PR DESCRIPTION
## Summary
- record the successful v0.3.4 tag build and GitHub Release
- record matching GitHub/PyPI SHA-256 hashes and Trusted Publishing run
- record Integrity API provenance, cryptographic attestation verification, and clean PyPI installation

Documentation-only release closeout; all links and hashes were verified after publication.
