### PR TITLE
feat: add audited ChatGPT web bridge for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,28 @@
   现有内容合同、部分批次恢复、参考文献 `preserve`、PDF 重建和逐页 QA。
 - 网页批次绑定源 PDF、片段、领域包、参考文献和透传映射身份；导入记录人工可见
   模型标签，保存每次回复原始字节快照和导入历史，不保存登录态、Cookie 或 API Key。
+- `apply-text-repair` 支持显式空 replacement 的只删除模式；不嵌入字体，
+  以 `text-removal` 独立记录，并继续强制矩形外文字、页面结构、备份和 QA 门禁。
+
+### Fixed
+
+- ChatGPT Web 提示改为单一 `json` 代码块，并要求使用代码块的复制按钮，
+  避免裸 JSON 中的 URL、DOI 和邮箱被网页富文本层改成 Markdown 链接。
+- 数字合同现在一致识别紧贴英文单词或中文汉字的引文号，例如
+  `productivity3,17,18` 与 `生产力3,17,18`；`mid-1960s` 仍不会被误判为负数。
 
 ### Security
 
 - PaperLocale 不登录、不抓取也不自动点击 `chatgpt.com`；网页 Chat 不是官方 API，
   因此不能作为无人值守 Provider，也不能保证任何账户的具体用量或额度归属。
+
+### Verification
+
+- 使用 9 页大气科学开放获取论文完成受监督 Computer Use 网页实验：
+  106 个片段中 83 个通过普通 Chat 的 6 个哈希批次翻译，19 个人工透传，
+  4 个参考文献片段保留；106/106 内容合同、9/9 页机器 QA 和逐页视觉验收通过。
+- 真实运行证据见 [`docs/releases/v0.4.0.md`](docs/releases/v0.4.0.md)；不上传或再分发
+  源 PDF、完整译本或私人 ChatGPT 会话链接。
 
 ## 0.3.3 - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 本项目遵循语义化版本。未发布内容先进入 `Unreleased`。
 
-## Unreleased
+## 0.4.0 - 未发布
+
+### Added
+
+- 增加 `chatgpt-web-export` / `chatgpt-web-import` 人工网页桥接：导出带哈希的
+  大气科学翻译批次，在 ChatGPT 网页端普通 Chat 中人工交换严格 JSON，再复用
+  现有内容合同、部分批次恢复、参考文献 `preserve`、PDF 重建和逐页 QA。
+- 网页批次绑定源 PDF、片段、领域包、参考文献和透传映射身份；导入记录人工可见
+  模型标签，保存每次回复原始字节快照和导入历史，不保存登录态、Cookie 或 API Key。
+
+### Security
+
+- PaperLocale 不登录、不抓取也不自动点击 `chatgpt.com`；网页 Chat 不是官方 API，
+  因此不能作为无人值守 Provider，也不能保证任何账户的具体用量或额度归属。
 
 ## 0.3.3 - 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,20 @@ repository; a TTF/OTF usually produces cleaner extraction metadata than a font
 collection, but every result still goes through the same QA warnings and visual
 review.
 
+For a reviewed fragment that must only be removed, pass an explicit empty
+replacement and omit the font options:
+
+```bash
+paperlocale apply-text-repair --run-dir runs/paper \
+  --page 2 --rect 120 29 144 39 --replacement '' \
+  --description "Remove a reviewed split-token fragment"
+```
+
+Removal mode embeds no font, records `text-removal` in `repair_history`, and
+still enforces the same rectangle, outside-text, page, image, link, vector,
+backup, QA, and human-acceptance gates. Whitespace-only replacements are
+rejected.
+
 For a BYOK OpenAI-compatible endpoint:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The project does not promise bitwise-identical typography. Chinese text naturall
 
 - `codex-local`: local-only translation through an authenticated Codex CLI session;
 - `openai-compatible`: BYOK access to OpenAI and compatible endpoints;
+- an auditable manual ChatGPT Web bridge that exports hash-bound prompts and imports
+  strict JSON responses without browser login, scraping, or automation;
 - an extensible `atmospheric-science` pack with terminology and evaluation cases;
 - a resumable `collect -> translate -> validate -> render -> qa -> accept` workflow;
 - page geometry, image-object, vector-drawing, blank-page, placeholder, and all-page visual checks.
@@ -73,6 +75,9 @@ Python 3.10–3.13 and Poppler's `pdftoppm` are required for the complete workfl
 PaperLocale 0.3.3 is published on PyPI through attested Trusted Publishing.
 The audited maintainer procedure and release evidence are documented in
 [docs/PYPI_PUBLISHING.zh-CN.md](docs/PYPI_PUBLISHING.zh-CN.md).
+The manual ChatGPT Web bridge is an unreleased v0.4.0 source candidate; see
+[docs/CHATGPT_WEB_MANUAL.zh-CN.md](docs/CHATGPT_WEB_MANUAL.zh-CN.md) for its
+copy/paste workflow and usage-limit boundary.
 
 ```bash
 python -m venv .venv

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -28,6 +28,8 @@ PaperLocale 是一个面向学术论文的可验证保版翻译工具。它的�
 
 - `codex-local`：调用用户本机已登录的 Codex，仅用于可信本地环境；
 - `openai-compatible`：由用户自备 API Key，可连接 OpenAI 及兼容接口；
+- `chatgpt-web` 人工桥接：把哈希绑定批次粘贴到 ChatGPT 网页端普通 Chat，再导入
+  严格 JSON 回复；项目不登录、抓取或自动点击网页；
 - `atmospheric-science`：内置 17 条大气科学固定术语和 5 个回归案例；
 - `collect -> translate -> validate -> render -> qa -> accept`：有清单、有断点、不可跳步的单向工作流；
 - 页数、MediaBox、CropBox、图片对象、矢量表格/图形、空白页和内部占位符机器检查；
@@ -57,6 +59,8 @@ paperlocale provider-eval \
 需要 Python 3.10–3.13。完整 PDF 流程还需要 Poppler 的 `pdftoppm`：macOS 可执行 `brew install poppler`，Ubuntu 可执行 `sudo apt-get install poppler-utils`。
 PaperLocale 0.3.3 已通过带数字 attestation 的 Trusted Publishing 发布到 PyPI；
 维护者发布流程与公开核验证据见 [PyPI 发布手册](docs/PYPI_PUBLISHING.zh-CN.md)。
+v0.4.0 网页桥接目前只是源码候选，尚未发布到 PyPI；操作与额度边界见
+[ChatGPT 网页端人工翻译桥接](docs/CHATGPT_WEB_MANUAL.zh-CN.md)。
 
 ```bash
 python -m venv .venv

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,6 +194,21 @@ paperlocale apply-text-repair \
 取得，不能提交到仓库；TTF/OTF 通常比字体集合产生更干净的抽取元数据，但任何
 CMap 警告和最终视觉效果仍由同一 QA 流程检查。
 
+若损坏对象只是已确认的孤立残片（例如固定首字母与可译对象切分后遗留
+`limate`），可显式传入空 replacement：
+
+```bash
+paperlocale apply-text-repair \
+  --run-dir runs/paper \
+  --page 2 \
+  --rect 120 29 144 39 \
+  --replacement '' \
+  --description "删除已核对的孤立英文残片"
+```
+
+只删除模式不需要 `--font-file` 或 `--font-size`，不会嵌入空字体子集；
+清单以 `text-removal` 独立记录。只包含空格的 replacement 仍会被拒绝。
+
 需要逐阶段控制时，仍可使用同一生产路径的 `init-run -> collect -> reference-review/confirm-references -> 可选 confirm-passthrough -> translate -> validate -> render -> qa -> accept` 命令序列。
 
 ## 领域包扩展

--- a/docs/CHATGPT_WEB_MANUAL.zh-CN.md
+++ b/docs/CHATGPT_WEB_MANUAL.zh-CN.md
@@ -1,0 +1,94 @@
+# ChatGPT 网页端人工翻译桥接
+
+状态：v0.4.0 候选功能，尚未发布。
+
+## 为什么不是自动网页 Provider
+
+OpenAI 官方文档把 [ChatGPT 网页端](https://learn.chatgpt.com/docs/web)描述为登录后
+选择 Chat 或 Work、发送消息并人工复核结果的交互界面；程序化构建入口则是使用
+API Key 的 [OpenAI API](https://developers.openai.com/api/docs)。PaperLocale 因此不
+登录、抓取、逆向或自动点击 `chatgpt.com`，也不读取 Cookie、浏览器存储或账户凭据。
+
+本功能采用可审计的人工文件桥接：PaperLocale 负责确定性分批和验证，用户只负责把
+提示粘贴到普通 `Chat`，再把 JSON 回复保存回运行目录。模型调用发生在用户选择的
+ChatGPT 网页会话中，而不是 `codex-local`。但具体模型、消息上限和用量仍取决于账户、
+计划、地区和当时界面；项目不能承诺“免费”“不限量”或“必然不计入某项额度”。官方
+说明还明确指出 ChatGPT Work 与 Codex 共享使用限额，因此本流程要求普通 `Chat`，
+不把 Work 当作额度旁路。
+
+## 工作流
+
+先按正常流程完成收集、参考文献确认和必要的人工透传：
+
+```bash
+paperlocale init-run paper.pdf --run-dir runs/paper
+paperlocale collect --run-dir runs/paper
+paperlocale reference-review --run-dir runs/paper
+paperlocale confirm-references \
+  --run-dir runs/paper \
+  --confirmed-by "your name"
+```
+
+若 `segment_safety_review.jsonl` 要求透传碎词、不可见短文本、纯公式或作者串，逐条
+核对后使用 `confirm-passthrough`。不要通过削弱全局中文门禁绕过这一步。
+
+导出网页批次：
+
+```bash
+paperlocale chatgpt-web-export \
+  --run-dir runs/paper \
+  --domain atmospheric-science \
+  --reference-policy preserve \
+  --max-segments 20 \
+  --max-characters 12000
+```
+
+命令生成：
+
+- `chatgpt_web/batch_manifest.json`：绑定全部输入身份和分批边界；
+- `chatgpt_web/prompts/batch-NNN.md`：可直接粘贴的完整提示；
+- `chatgpt_web/responses/batch-NNN.json`：网页回复的预期保存位置。
+
+对每个提示执行以下人工步骤：
+
+1. 登录 `chatgpt.com`，选择普通 `Chat`，不要选择 Codex 或 ChatGPT Work；
+2. 新建独立聊天并粘贴一个完整 `batch-NNN.md`；
+3. 核对回复只有 `batch_id`、`batch_sha256`、`translations` 三个顶层字段；
+4. 去掉 Markdown 代码围栏，把完整 JSON 保存到清单指定的响应路径；
+5. 按网页模型选择器原样记下模型标签，不能事后猜测底层模型版本。
+
+导入回复：
+
+```bash
+paperlocale chatgpt-web-import \
+  --run-dir runs/paper \
+  --domain atmospheric-science \
+  --reference-policy preserve \
+  --model-label "网页上实际显示的模型标签"
+```
+
+导入会拒绝错误批次哈希、缺失/重复/额外 ID、公式或富文本占位符丢失、数字和单位
+丢失、固定术语错误等问题。同批合格译文仍会原子保存；修订失败回复后再次导入，只
+处理尚未通过的片段。每次参与导入的网页回复会复制到 `chatgpt_web/imports/`，并在
+`import_history.jsonl` 中记录哈希、模型标签和结果。
+
+全部译文闭合后继续唯一生产路径：
+
+```bash
+paperlocale validate --run-dir runs/paper --domain atmospheric-science
+paperlocale render --run-dir runs/paper
+paperlocale qa --run-dir runs/paper
+paperlocale accept --run-dir runs/paper --reviewed-by "your name"
+```
+
+机器 QA 通过不代表视觉完全正确。仍须逐页检查中文断行、公式、表格、图片、图注、
+多栏顺序、页眉页脚和参考文献版面。
+
+## 审计边界
+
+- 记录：源 PDF/片段/领域包/人工映射哈希、批次提示哈希、网页回复快照哈希、人工
+  可见模型标签、导入成功或失败记录；
+- 不记录：ChatGPT 账号、Cookie、会话令牌、密码、API Key；
+- 不证明：网页显示标签对应的不可见后端快照、账户计费或配额规则、翻译语义已经由
+  独立领域专家确认；
+- 不分发：受版权限制的源论文、完整译本或私人 ChatGPT 会话链接。

--- a/docs/CHATGPT_WEB_MANUAL.zh-CN.md
+++ b/docs/CHATGPT_WEB_MANUAL.zh-CN.md
@@ -54,7 +54,9 @@ paperlocale chatgpt-web-export \
 1. 登录 `chatgpt.com`，选择普通 `Chat`，不要选择 Codex 或 ChatGPT Work；
 2. 新建独立聊天并粘贴一个完整 `batch-NNN.md`；
 3. 核对回复只有 `batch_id`、`batch_sha256`、`translations` 三个顶层字段；
-4. 去掉 Markdown 代码围栏，把完整 JSON 保存到清单指定的响应路径；
+4. 使用 `json` 代码块自带的“复制”按钮，把其中的纯 JSON 内容
+   保存到清单指定的响应路径。不要使用整条回复的“复制回复”；
+   裸 JSON 中的 URL 或邮箱可能被网页富文本层改写为 Markdown 链接；
 5. 按网页模型选择器原样记下模型标签，不能事后猜测底层模型版本。
 
 导入回复：

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,51 @@
+# PaperLocale v0.4.0 候选验证
+
+v0.4.0 增加 ChatGPT 网页端普通 Chat 的人工、可审计文件桥接。该功能
+不登录、不抓取也不自动点击 `chatgpt.com`；项目只负责导出哈希绑定的
+提示文件，以及导入人工保存的 JSON 回复。
+
+## 真实论文运行
+
+- 论文：Wang et al. (2022), *Regional asymmetry in the response of global
+  vegetation growth to springtime compound climate events*；源文标注为
+  Creative Commons Attribution 4.0。
+- 源 PDF：9 页，SHA-256
+  `4592ea71d8f3968e23930c489cb0d2f9d826ccc7ed1d4e5869f96a981f49a45f`。
+- 版面引擎：`pdf2zh-next 2.9.0`、`BabelDOC 0.6.2`。
+- 片段：106 个；其中 83 个发送到网页 Chat，19 个经人工确认透传，
+  4 个参考文献片段按 `preserve` 保留。
+- 网页批次：6 个，人工可见标签为 `5.6 Sol / High`。每个回复的
+  `batch_id`、`batch_sha256`、片段 ID 和原始回复 SHA-256 都由导入历史绑定。
+- 本次为应用外部、受监督的 Computer Use 操作实验：它代为执行
+  打开普通 Chat、粘贴批次、点击发送、复制代码块和保存回复的人工步骤。
+  PaperLocale 包本身仍不包含浏览器自动化，也没有读取 Cookie、会话令牌、
+  密码或 API Key。
+
+## 实验发现与修正
+
+1. 裸 JSON 中的 URL 和邮箱会被 ChatGPT 富文本层改成 Markdown 链接，
+   导致 URL/DOI 次数门禁硬失败。候选协议因此改为“单一 `json` 代码块
+   + 复制代码”。
+2. 引文号紧贴英文单词和中文汉字时，旧数字正则会得到不同的切分结果。
+   新回归覆盖 `productivity3,17,18` 与 `生产力3,17,18`，同时继续保护
+   `mid-1960s`。
+3. 视觉检查发现一个孤立 `limate` 残片。`apply-text-repair` 因此增加
+   显式空 replacement 的 `text-removal` 模式；它只删除绑定矩形内的文字，
+   不嵌入字体，且继续保护矩形外文字和 PDF 结构。
+
+## 质量证据
+
+- 106/106 译文内容合同通过；导入断点有效，失败候选保留具体错误。
+- 初次机器 QA 拦截第 1 页 20 条链接图标填充路径和第 8 页 3 条公式细横线。
+  修复候选只复制 QA 报告精确列出的源矢量对象，再经 `apply-vector-repair`
+  验证文字、页尺寸和图片不变，并记录备份与前后哈希。
+- 第 2 页孤立残片与第 8 页首条参考文献重叠经受控文字修复处理；
+  所有修复都强制重新 QA 和逐页视觉验收。
+- 最终机器 QA：9 页，0 errors，0 warnings；人工逐页验收已记录。
+- 最终 PDF SHA-256：
+  `78c189c633031ec820d81506294bd737b5c6843b0f270d5410b927879a40972f`。
+- Python 3.12 不联网测试：80/80 通过；受影响文件的 Ruff `F`/`I` 检查与
+  `git diff --check` 通过。
+
+上述运行不把源 PDF、完整译本或私人 ChatGPT 会话链接提交到仓库。
+这是维护者主导的真实运行证据，不等同于非维护者的外部采用证据。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paperlocale"
-version = "0.3.3"
+version = "0.4.0"
 description = "Verified, layout-preserving academic PDF translation with pluggable providers and domain packs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/paperlocale/__init__.py
+++ b/src/paperlocale/__init__.py
@@ -1,3 +1,3 @@
 """PaperLocale：具有科学信息硬门禁的学术 PDF 保版翻译工具。"""
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/src/paperlocale/chatgpt_web.py
+++ b/src/paperlocale/chatgpt_web.py
@@ -131,8 +131,10 @@ def _web_prompt(
 请在 ChatGPT 网页端的普通 **Chat** 模式完成本批翻译。不要切换到 Codex 或
 ChatGPT Work。不要上传源 PDF；本提示只包含版面引擎已经拆出的具体片段。
 
-只返回一个合法 JSON 对象，不要使用 Markdown 代码围栏，也不要添加解释。顶层字段
-必须且只能是 `batch_id`、`batch_sha256` 和 `translations`：
+只返回一个合法 JSON 对象，并把它放入一个且仅一个 `json` 代码块。
+代码块外不要添加解释。这样可避免 ChatGPT 富文本层把 URL 或邮箱
+自动改写为 Markdown 链接。顶层字段必须且只能是 `batch_id`、
+`batch_sha256` 和 `translations`：
 
 {{
   "batch_id": "{batch_id}",
@@ -143,7 +145,8 @@ ChatGPT Work。不要上传源 PDF；本提示只包含版面引擎已经拆出�
 }}
 
 `batch_id` 与 `batch_sha256` 必须逐字回显；`translations` 必须覆盖下方全部输入 ID，
-不得缺失、重复或增加 ID。完成后把整个 JSON 对象保存为
+不得缺失、重复或增加 ID。完成后使用代码块的“复制”按钮，把
+其中的 JSON 对象保存为
 `responses/{batch_id}.json`，再交给 PaperLocale 导入。
 
 {build_prompt(batch, context)}

--- a/src/paperlocale/chatgpt_web.py
+++ b/src/paperlocale/chatgpt_web.py
@@ -1,0 +1,564 @@
+"""ChatGPT 网页端普通 Chat 的人工、可审计翻译桥接。
+
+本模块不登录、不抓取也不自动点击 ``chatgpt.com``。它只把当前运行的待译片段
+导出为带哈希的提示文件，并把用户从网页 Chat 保存的严格 JSON 回复重新送入现有
+``translate_run``。因此所有参考文献、人工透传、内容合同和断点语义仍只有一套。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .contracts import read_jsonl, segment_id, write_jsonl_atomic
+from .domains import DomainPack
+from .pipeline import make_batches
+from .providers.base import (
+    Segment,
+    Translation,
+    TranslationContext,
+    TranslationProvider,
+    build_prompt,
+    parse_payload,
+)
+from .workflow import (
+    _load_passthrough_configuration,
+    _load_reference_configuration,
+    _prepare_segment_safety_configuration,
+    _sha256,
+    _verify_domain_languages,
+    _verify_source_pdf,
+    load_manifest,
+    save_manifest,
+    translate_run,
+)
+
+BATCH_SCHEMA_VERSION = 1
+PROVIDER_NAME = "chatgpt-web-manual"
+
+
+def _utc_now() -> str:
+    """使用与运行清单一致的 UTC 秒级时间，便于人工对照审计记录。"""
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _canonical_sha256(value: object) -> str:
+    """对结构化身份使用排序、紧凑 JSON，避免缩进差异改变批次哈希。"""
+
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _write_json_atomic(path: Path, value: object) -> None:
+    """同目录原子替换 JSON，避免复制网页回复时留下半份批次清单。"""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _read_segments(path: Path) -> list[Segment]:
+    """读取并验证稳定片段身份，拒绝把改写后的原文导出到旧运行。"""
+
+    segments: list[Segment] = []
+    seen: set[str] = set()
+    for row in read_jsonl(path):
+        source = str(row.get("source", ""))
+        sid = str(row.get("id", ""))
+        if not source or sid != segment_id(source):
+            raise ValueError(f"片段缺少原文或 ID 不一致：{sid!r}")
+        if sid in seen:
+            raise ValueError(f"片段包含重复 ID：{sid}")
+        seen.add(sid)
+        segments.append(Segment(id=sid, source=source))
+    return segments
+
+
+def _batch_identity(
+    *,
+    batch_id: str,
+    batch: list[Segment],
+    context: TranslationContext,
+) -> dict[str, object]:
+    """批次哈希只绑定稳定输入，不包含生成时间或本机绝对路径。"""
+
+    return {
+        "schema_version": BATCH_SCHEMA_VERSION,
+        "batch_id": batch_id,
+        "source_language": context.source_language,
+        "target_language": context.target_language,
+        "domain_pack_sha256": context.domain.content_sha256,
+        "reference_policy": context.reference_policy,
+        "segments": [
+            {
+                "id": segment.id,
+                "source": segment.source,
+                "kind": (
+                    "reference"
+                    if segment.id in context.reference_segment_ids
+                    else "body"
+                ),
+            }
+            for segment in batch
+        ],
+    }
+
+
+def _web_prompt(
+    *,
+    batch_id: str,
+    batch_sha256: str,
+    batch: list[Segment],
+    context: TranslationContext,
+) -> str:
+    """在共用翻译提示外增加网页人工交换所需的批次回显字段。"""
+
+    return f"""# PaperLocale ChatGPT Web 人工翻译批次
+
+请在 ChatGPT 网页端的普通 **Chat** 模式完成本批翻译。不要切换到 Codex 或
+ChatGPT Work。不要上传源 PDF；本提示只包含版面引擎已经拆出的具体片段。
+
+只返回一个合法 JSON 对象，不要使用 Markdown 代码围栏，也不要添加解释。顶层字段
+必须且只能是 `batch_id`、`batch_sha256` 和 `translations`：
+
+{{
+  "batch_id": "{batch_id}",
+  "batch_sha256": "{batch_sha256}",
+  "translations": [
+    {{"id": "原样回显输入 ID", "target": "中文译文"}}
+  ]
+}}
+
+`batch_id` 与 `batch_sha256` 必须逐字回显；`translations` 必须覆盖下方全部输入 ID，
+不得缺失、重复或增加 ID。完成后把整个 JSON 对象保存为
+`responses/{batch_id}.json`，再交给 PaperLocale 导入。
+
+{build_prompt(batch, context)}
+"""
+
+
+def _load_existing_batch_manifest(
+    root: Path,
+    run_manifest: dict[str, object],
+) -> dict[str, object] | None:
+    """若已导出则复用确切清单，禁止部分导入后静默重分批。"""
+
+    recorded = run_manifest.get("chatgpt_web_batch_manifest")
+    if recorded is None:
+        return None
+    path = Path(str(recorded))
+    expected_hash = run_manifest.get("chatgpt_web_batch_manifest_sha256")
+    if not path.is_file() or not isinstance(expected_hash, str):
+        raise ValueError("运行清单绑定的 ChatGPT Web 批次清单不存在或缺少哈希")
+    if _sha256(path) != expected_hash:
+        raise ValueError("ChatGPT Web 批次清单在导出后发生变化")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise TypeError("ChatGPT Web 批次清单必须是 JSON 对象")
+    if path.parent != (root / "chatgpt_web").resolve():
+        raise ValueError("ChatGPT Web 批次清单不属于当前运行目录")
+    return value
+
+
+def _verify_batch_manifest_identity(
+    *,
+    batch_manifest: dict[str, object],
+    run_manifest: dict[str, object],
+    domain: DomainPack,
+    reference_policy: str,
+) -> None:
+    """重新核对所有仍可变化的输入，禁止把旧提示回复导入新片段或新领域包。"""
+
+    segments_path = Path(str(run_manifest["segments_path"]))
+    root = segments_path.parent
+    reference_map_path = root / "reference_map.json"
+    passthrough_map_path = root / "passthrough_map.json"
+    expected = {
+        "schema_version": BATCH_SCHEMA_VERSION,
+        "provider": PROVIDER_NAME,
+        "source_sha256": run_manifest["source_sha256"],
+        "segments_sha256": _sha256(segments_path),
+        "domain_pack_sha256": domain.content_sha256,
+        "reference_policy": reference_policy,
+        "reference_map_sha256": _sha256(reference_map_path),
+        "passthrough_map_sha256": (
+            _sha256(passthrough_map_path)
+            if passthrough_map_path.is_file()
+            else None
+        ),
+    }
+    mismatched = {
+        key: (batch_manifest.get(key), value)
+        for key, value in expected.items()
+        if batch_manifest.get(key) != value
+    }
+    if mismatched:
+        raise ValueError(f"ChatGPT Web 批次身份与当前运行不一致：{mismatched}")
+
+
+def export_chatgpt_web_batches(
+    *,
+    run_dir: Path,
+    domain: DomainPack,
+    max_segments: int = 20,
+    max_characters: int = 12000,
+    reference_policy: str = "preserve",
+) -> dict[str, object]:
+    """导出当前运行全部待译片段，并将批次清单哈希绑定到运行清单。"""
+
+    root = run_dir.expanduser().resolve()
+    manifest = load_manifest(root)
+    if manifest["status"] not in {"collected", "translated"}:
+        raise ValueError(f"chatgpt-web-export 不接受状态：{manifest['status']}")
+    _verify_source_pdf(manifest)
+    _verify_domain_languages(manifest, domain)
+
+    existing_manifest = _load_existing_batch_manifest(root, manifest)
+    if existing_manifest is not None:
+        _verify_batch_manifest_identity(
+            batch_manifest=existing_manifest,
+            run_manifest=manifest,
+            domain=domain,
+            reference_policy=reference_policy,
+        )
+        expected = {
+            "max_segments": max_segments,
+            "max_characters": max_characters,
+        }
+        mismatched = {
+            key: (existing_manifest.get(key), value)
+            for key, value in expected.items()
+            if existing_manifest.get(key) != value
+        }
+        if mismatched:
+            raise ValueError(f"已有批次清单与本次导出参数不一致：{mismatched}")
+        return existing_manifest
+
+    recorded_provider = manifest.get("translation_provider")
+    if recorded_provider is not None:
+        raise ValueError("当前运行已绑定其他翻译 Provider，不能改为 ChatGPT Web")
+
+    reference_ids, reference_map_path = _load_reference_configuration(
+        root,
+        manifest,
+        reference_policy,
+    )
+    passthrough_ids, passthrough_map_path = _load_passthrough_configuration(
+        root,
+        manifest,
+    )
+    overlap = reference_ids & passthrough_ids
+    if overlap:
+        raise ValueError(f"参考文献与透传映射不能包含相同片段：{sorted(overlap)}")
+    _prepare_segment_safety_configuration(root, manifest, passthrough_ids)
+
+    segments_path = Path(str(manifest["segments_path"]))
+    segments = _read_segments(segments_path)
+    existing_rows = (
+        read_jsonl(Path(str(manifest["translations_path"])))
+        if Path(str(manifest["translations_path"])).is_file()
+        else []
+    )
+    if existing_rows:
+        raise ValueError(
+            "首次导出前已存在来源未绑定的译文；请使用新的运行目录，"
+            "或继续原 Provider 运行"
+        )
+    existing_ids = {str(row.get("id", "")) for row in existing_rows}
+    if len(existing_ids) != len(existing_rows):
+        raise ValueError("既有译文包含重复 ID，不能导出网页批次")
+
+    preserved_ids = set(passthrough_ids)
+    if reference_policy == "preserve":
+        preserved_ids.update(reference_ids)
+    pending = [
+        segment
+        for segment in segments
+        if segment.id not in preserved_ids and segment.id not in existing_ids
+    ]
+    if not pending:
+        raise ValueError("当前运行没有需要发送到 ChatGPT Web 的片段")
+
+    context = TranslationContext(
+        source_language=domain.source_language,
+        target_language=domain.target_language,
+        domain=domain,
+        reference_policy=reference_policy,
+        reference_segment_ids=frozenset(reference_ids),
+    )
+    root_output = (root / "chatgpt_web").resolve()
+    prompts_dir = root_output / "prompts"
+    responses_dir = root_output / "responses"
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    responses_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_rows: list[dict[str, object]] = []
+    for index, batch in enumerate(
+        make_batches(
+            pending,
+            max_segments=max_segments,
+            max_characters=max_characters,
+        ),
+        1,
+    ):
+        batch_id = f"batch-{index:03d}"
+        identity = _batch_identity(batch_id=batch_id, batch=batch, context=context)
+        batch_sha256 = _canonical_sha256(identity)
+        prompt_path = prompts_dir / f"{batch_id}.md"
+        prompt_path.write_text(
+            _web_prompt(
+                batch_id=batch_id,
+                batch_sha256=batch_sha256,
+                batch=batch,
+                context=context,
+            ),
+            encoding="utf-8",
+        )
+        batch_rows.append(
+            {
+                "batch_id": batch_id,
+                "batch_sha256": batch_sha256,
+                "prompt": str(prompt_path),
+                "prompt_sha256": _sha256(prompt_path),
+                "response": str(responses_dir / f"{batch_id}.json"),
+                "segment_ids": [segment.id for segment in batch],
+                "source_characters": sum(len(segment.source) for segment in batch),
+            }
+        )
+
+    batch_manifest: dict[str, object] = {
+        "schema_version": BATCH_SCHEMA_VERSION,
+        "created_at": _utc_now(),
+        "provider": PROVIDER_NAME,
+        "source_sha256": manifest["source_sha256"],
+        "segments_sha256": _sha256(segments_path),
+        "domain_pack_sha256": domain.content_sha256,
+        "reference_policy": reference_policy,
+        "reference_map_sha256": _sha256(reference_map_path),
+        "passthrough_map_sha256": (
+            _sha256(passthrough_map_path)
+            if passthrough_map_path is not None
+            else None
+        ),
+        "max_segments": max_segments,
+        "max_characters": max_characters,
+        "batch_count": len(batch_rows),
+        "segment_count": len(pending),
+        "batches": batch_rows,
+    }
+    batch_manifest_path = root_output / "batch_manifest.json"
+    _write_json_atomic(batch_manifest_path, batch_manifest)
+    manifest["chatgpt_web_batch_manifest"] = str(batch_manifest_path)
+    manifest["chatgpt_web_batch_manifest_sha256"] = _sha256(batch_manifest_path)
+    save_manifest(root, manifest)
+    return batch_manifest
+
+
+class _ChatGPTWebResponseProvider(TranslationProvider):
+    """把人工保存的网页回复适配为现有同步 Provider 合同。"""
+
+    def __init__(
+        self,
+        *,
+        batch_manifest_path: Path,
+        model_label: str,
+    ) -> None:
+        label = model_label.strip()
+        if not label:
+            raise ValueError("--model-label 不能为空")
+        self.batch_manifest_path = batch_manifest_path.resolve()
+        self.batch_manifest_sha256 = _sha256(self.batch_manifest_path)
+        self.model_label = label
+        self.response_paths: list[Path] = []
+        self.response_hashes: dict[str, str] = {}
+        self.translations: dict[str, Translation] = {}
+
+        value = json.loads(self.batch_manifest_path.read_text(encoding="utf-8"))
+        batches = value.get("batches") if isinstance(value, dict) else None
+        if not isinstance(batches, list):
+            raise TypeError("ChatGPT Web 批次清单缺少 batches 数组")
+        for row in batches:
+            if not isinstance(row, dict):
+                raise TypeError("ChatGPT Web 批次记录必须是对象")
+            batch_id = str(row.get("batch_id", ""))
+            response_path = Path(str(row.get("response", "")))
+            if not response_path.is_file():
+                continue
+            payload = json.loads(response_path.read_text(encoding="utf-8-sig"))
+            if not isinstance(payload, dict) or set(payload) != {
+                "batch_id",
+                "batch_sha256",
+                "translations",
+            }:
+                raise ValueError(
+                    f"网页回复顶层字段非法：{response_path}"
+                )
+            if payload["batch_id"] != batch_id:
+                raise ValueError(f"网页回复 batch_id 不匹配：{response_path}")
+            if payload["batch_sha256"] != row.get("batch_sha256"):
+                raise ValueError(f"网页回复 batch_sha256 不匹配：{response_path}")
+            expected = [
+                Segment(id=str(sid), source="")
+                for sid in row.get("segment_ids", [])
+            ]
+            parsed = parse_payload(payload, expected)
+            for translation in parsed:
+                if translation.id in self.translations:
+                    raise ValueError(f"网页回复重复覆盖片段 ID：{translation.id}")
+                self.translations[translation.id] = translation
+            self.response_paths.append(response_path.resolve())
+            self.response_hashes[batch_id] = _sha256(response_path)
+
+    def provenance(self) -> dict[str, object]:
+        """记录人工网页边界，不把它冒充为官方 API 或自动化 Provider。"""
+
+        return {
+            "provider": PROVIDER_NAME,
+            "model": self.model_label,
+            "interface_mode": "manual-copy-paste",
+            "browser_automation": False,
+            "batch_manifest_sha256": self.batch_manifest_sha256,
+        }
+
+    def translate(
+        self,
+        segments: list[Segment],
+        context: TranslationContext,
+    ) -> list[Translation]:
+        """按本次仍待译的 ID 查表，支持合同失败后只重试原批次子集。"""
+
+        missing = [segment.id for segment in segments if segment.id not in self.translations]
+        if missing:
+            raise ValueError(
+                "缺少覆盖当前片段的 ChatGPT Web 回复；请保存对应 responses/*.json："
+                f"{missing}"
+            )
+        return [self.translations[segment.id] for segment in segments]
+
+
+def _snapshot_responses(root: Path, provider: _ChatGPTWebResponseProvider) -> list[dict[str, str]]:
+    """导入前保存网页回复原始字节，后续覆盖修订文件也不会抹去旧证据。"""
+
+    snapshots: list[dict[str, str]] = []
+    target_dir = root / "chatgpt_web" / "imports"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for source in provider.response_paths:
+        response_sha256 = _sha256(source)
+        target = target_dir / f"{source.stem}-{response_sha256}.json"
+        if not target.exists():
+            shutil.copyfile(source, target)
+        snapshots.append(
+            {
+                "source": str(source),
+                "snapshot": str(target.resolve()),
+                "sha256": response_sha256,
+            }
+        )
+    return snapshots
+
+
+def _record_import_attempt(
+    *,
+    root: Path,
+    model_label: str,
+    snapshots: list[dict[str, str]],
+    outcome: str,
+    error: str | None,
+) -> None:
+    """原子追加导入尝试，并把历史文件哈希重新绑定到运行清单。"""
+
+    history_path = root / "chatgpt_web" / "import_history.jsonl"
+    history = read_jsonl(history_path) if history_path.is_file() else []
+    row: dict[str, object] = {
+        "imported_at": _utc_now(),
+        "model_label": model_label,
+        "outcome": outcome,
+        "responses": snapshots,
+    }
+    if error is not None:
+        row["error"] = error
+    history.append(row)
+
+    write_jsonl_atomic(history_path, history)
+    manifest = load_manifest(root)
+    manifest["chatgpt_web_import_history"] = str(history_path.resolve())
+    manifest["chatgpt_web_import_history_sha256"] = _sha256(history_path)
+    save_manifest(root, manifest)
+
+
+def import_chatgpt_web_responses(
+    *,
+    run_dir: Path,
+    domain: DomainPack,
+    model_label: str,
+    reference_policy: str = "preserve",
+) -> tuple[int, int]:
+    """验证网页回复身份，保留原始字节，并复用生产翻译状态机导入译文。"""
+
+    root = run_dir.expanduser().resolve()
+    manifest = load_manifest(root)
+    batch_manifest_value = manifest.get("chatgpt_web_batch_manifest")
+    if batch_manifest_value is None:
+        raise ValueError("请先执行 chatgpt-web-export")
+    if not isinstance(batch_manifest_value, str):
+        raise TypeError("运行清单中的 ChatGPT Web 批次路径必须是字符串")
+    batch_manifest_path = Path(batch_manifest_value)
+    expected_hash = manifest.get("chatgpt_web_batch_manifest_sha256")
+    if not isinstance(expected_hash, str) or _sha256(batch_manifest_path) != expected_hash:
+        raise ValueError("ChatGPT Web 批次清单缺失或哈希不一致")
+    batch_manifest = json.loads(batch_manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(batch_manifest, dict):
+        raise TypeError("ChatGPT Web 批次清单必须是 JSON 对象")
+    _verify_batch_manifest_identity(
+        batch_manifest=batch_manifest,
+        run_manifest=manifest,
+        domain=domain,
+        reference_policy=reference_policy,
+    )
+
+    provider = _ChatGPTWebResponseProvider(
+        batch_manifest_path=batch_manifest_path,
+        model_label=model_label,
+    )
+    if not provider.response_paths:
+        raise ValueError("尚未找到任何 responses/*.json 网页回复")
+    snapshots = _snapshot_responses(root, provider)
+    try:
+        result = translate_run(
+            run_dir=root,
+            provider=provider,
+            domain=domain,
+            max_segments=int(batch_manifest["max_segments"]),
+            max_characters=int(batch_manifest["max_characters"]),
+            reference_policy=reference_policy,
+        )
+    except Exception as exc:
+        _record_import_attempt(
+            root=root,
+            model_label=provider.model_label,
+            snapshots=snapshots,
+            outcome="failed",
+            error=str(exc),
+        )
+        raise
+    _record_import_attempt(
+        root=root,
+        model_label=provider.model_label,
+        snapshots=snapshots,
+        outcome="completed",
+        error=None,
+    )
+    return result

--- a/src/paperlocale/cli.py
+++ b/src/paperlocale/cli.py
@@ -6,6 +6,10 @@ import argparse
 import os
 from pathlib import Path
 
+from .chatgpt_web import (
+    export_chatgpt_web_batches,
+    import_chatgpt_web_responses,
+)
 from .contracts import validate_translation, validate_translation_files
 from .domains import load_domain_pack
 from .evaluation import evaluate_provider, write_evaluation_report
@@ -186,6 +190,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     confirm_passthrough.add_argument("--reason", required=True)
     confirm_passthrough.add_argument("--confirmed-by", required=True)
+
+    chatgpt_export = subparsers.add_parser(
+        "chatgpt-web-export",
+        help="导出供 ChatGPT 网页端普通 Chat 人工翻译的哈希绑定批次",
+    )
+    chatgpt_export.add_argument("--run-dir", type=Path, required=True)
+    chatgpt_export.add_argument("--domain", default="atmospheric-science")
+    chatgpt_export.add_argument(
+        "--reference-policy",
+        choices=REFERENCE_POLICIES,
+        default="preserve",
+    )
+    chatgpt_export.add_argument("--max-segments", type=int, default=20)
+    chatgpt_export.add_argument("--max-characters", type=int, default=12000)
+
+    chatgpt_import = subparsers.add_parser(
+        "chatgpt-web-import",
+        help="导入并验证从 ChatGPT 网页端普通 Chat 保存的 JSON 回复",
+    )
+    chatgpt_import.add_argument("--run-dir", type=Path, required=True)
+    chatgpt_import.add_argument("--domain", default="atmospheric-science")
+    chatgpt_import.add_argument(
+        "--reference-policy",
+        choices=REFERENCE_POLICIES,
+        default="preserve",
+    )
+    chatgpt_import.add_argument(
+        "--model-label",
+        required=True,
+        help="按网页模型选择器原样记录的人工可见模型标签",
+    )
 
     run_translate = subparsers.add_parser("translate", help="翻译一个已初始化运行")
     run_translate.add_argument("--run-dir", type=Path, required=True)
@@ -392,6 +427,28 @@ def main() -> int:
             confirmed_by=args.confirmed_by,
         )
         print(f"人工透传映射已确认：{len(mapping['entries'])} 个片段")
+        return 0
+    if args.command == "chatgpt-web-export":
+        batch_manifest = export_chatgpt_web_batches(
+            run_dir=args.run_dir,
+            domain=load_domain_pack(args.domain),
+            max_segments=args.max_segments,
+            max_characters=args.max_characters,
+            reference_policy=args.reference_policy,
+        )
+        print(
+            f"ChatGPT Web 批次已导出：{batch_manifest['batch_count']} 批，"
+            f"{batch_manifest['segment_count']} 个片段；请逐个保存网页 JSON 回复"
+        )
+        return 0
+    if args.command == "chatgpt-web-import":
+        reused, translated = import_chatgpt_web_responses(
+            run_dir=args.run_dir,
+            domain=load_domain_pack(args.domain),
+            model_label=args.model_label,
+            reference_policy=args.reference_policy,
+        )
+        print(f"ChatGPT Web 回复导入完成：复用 {reused}，新译 {translated}")
         return 0
     if args.command == "translate":
         pack = load_domain_pack(args.domain)

--- a/src/paperlocale/cli.py
+++ b/src/paperlocale/cli.py
@@ -269,7 +269,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     text_repair = subparsers.add_parser(
         "apply-text-repair",
-        help="在明确页面矩形内替换文字、子集字体并记录修复历史",
+        help="在明确页面矩形内替换或删除文字，并记录修复历史",
     )
     text_repair.add_argument("--run-dir", type=Path, required=True)
     text_repair.add_argument(
@@ -286,9 +286,21 @@ def build_parser() -> argparse.ArgumentParser:
         metavar=("X0", "Y0", "X1", "Y1"),
         help="PyMuPDF PDF 点坐标：左、上、右、下",
     )
-    text_repair.add_argument("--replacement", required=True)
-    text_repair.add_argument("--font-file", type=Path, required=True)
-    text_repair.add_argument("--font-size", type=float, required=True)
+    text_repair.add_argument(
+        "--replacement",
+        required=True,
+        help="替换文字；显式传入空字符串时只删除 rect 内文字",
+    )
+    text_repair.add_argument(
+        "--font-file",
+        type=Path,
+        help="非空 replacement 必需；只删除模式不使用",
+    )
+    text_repair.add_argument(
+        "--font-size",
+        type=float,
+        help="非空 replacement 必需；只删除模式不使用",
+    )
     text_repair.add_argument("--description", required=True)
 
     accept = subparsers.add_parser("accept", help="记录人工逐页视觉验收")

--- a/src/paperlocale/contracts.py
+++ b/src/paperlocale/contracts.py
@@ -15,12 +15,18 @@ from pathlib import Path
 
 from .domains import DomainPack
 
-
 FORMULA_RE = re.compile(r"\{v\d+\}")
 STYLE_RE = re.compile(r"<style\s+id=['\"]\d+['\"]>|</style>", re.IGNORECASE)
 URL_RE = re.compile(r"https?://[^\s)\]}>,;，。；：！？）】》]+", re.IGNORECASE)
 DOI_RE = re.compile(r"\b10\.\d{4,9}/[^\s)\]}>,;，。；：！？）】》]+", re.IGNORECASE)
-NUMBER_RE = re.compile(r"(?<![\dA-Za-z])[-+−]?\d+(?:[.,]\d+)?(?:[eE][-+]?\d+)?")
+# PDF 文本层常把引文号和产品版本紧贴在英文名后，如
+# ``productivity3,17,18`` 和 ``NDVI3g``。第二个零宽分支允许数字紧跟
+# ASCII 字母；正负号仍只能由第一分支接管，因此 ``mid-1960s``
+# 中的连字符不会被误判为负号。
+NUMBER_RE = re.compile(
+    r"(?:(?<![\dA-Za-z])[-+−]?|(?<=[A-Za-z]))"
+    r"\d+(?:[.,]\d+)?(?:[eE][-+]?\d+)?"
+)
 ABBREVIATION_RE = re.compile(r"(?<![A-Za-z0-9])(?:[A-Z][A-Z0-9-]{1,})(?![A-Za-z0-9])")
 ABBREVIATION_EXCLUSIONS = frozenset({"ABSTRACT", "KEYWORDS", "REFERENCES"})
 UNIT_RE = re.compile(

--- a/src/paperlocale/workflow.py
+++ b/src/paperlocale/workflow.py
@@ -1086,10 +1086,10 @@ def _create_text_repair_candidate(
     page_number: int,
     rectangle: fitz.Rect,
     replacement: str,
-    font_file: Path,
-    font_size: float,
+    font_file: Path | None,
+    font_size: float | None,
 ) -> dict[str, object]:
-    """只在内存候选中删除指定文字并嵌入经过子集化的替换字体。"""
+    """只在候选中删除指定文字，并在需要时嵌入子集替换字体。"""
 
     document = fitz.open(rendered)
     try:
@@ -1118,8 +1118,26 @@ def _create_text_repair_candidate(
         if list(page.annots(types=(fitz.PDF_ANNOT_REDACT,)) or []):
             raise ValueError(f"第{page_number}页已有 redaction 标注，拒绝批量应用")
 
-        subset_bytes, font_evidence = _subset_repair_font(font_file, replacement)
-        font_resource_name = str(font_evidence["font_resource_name"])
+        if replacement:
+            if font_file is None or font_size is None:
+                raise ValueError("非空 replacement 必须提供 font-file 和 font-size")
+            subset_bytes, font_evidence = _subset_repair_font(font_file, replacement)
+            font_resource_name = str(font_evidence["font_resource_name"])
+        else:
+            # 只删除模式不嵌入任何字体程序。保留显式空字段，
+            # 使 repair_history 能区分“没有记录”与“经审计的文字删除”。
+            subset_bytes = b""
+            font_resource_name = ""
+            font_evidence = {
+                "font_file": None,
+                "font_file_sha256": None,
+                "font_name": None,
+                "font_subset_sha256": None,
+                "font_resource_name": None,
+                "font_program_bytes_before_subset": 0,
+                "font_program_bytes_after_subset": 0,
+                "font_subset_bytes_saved": 0,
+            }
         # redaction 只负责移除文字；透明填充避免白色覆盖层遮住矩形内仍保留的
         # 图片或矢量对象。下面的 images/graphics NONE 则禁止删除这些对象本身。
         page.add_redact_annot(rectangle, fill=False, cross_out=False)
@@ -1131,27 +1149,28 @@ def _create_text_repair_candidate(
         if not applied:
             raise RuntimeError("PyMuPDF 没有应用文字修复 redaction")
 
-        font_xref = page.insert_font(
-            fontname=font_resource_name,
-            fontbuffer=subset_bytes,
-        )
-        remaining_height = page.insert_textbox(
-            rectangle,
-            replacement,
-            fontname=font_resource_name,
-            fontsize=font_size,
-            color=(0, 0, 0),
-        )
-        if remaining_height < 0:
-            raise ValueError(
-                "replacement 无法放入 rect；请扩大矩形或减小 --font-size"
+        if replacement:
+            font_xref = page.insert_font(
+                fontname=font_resource_name,
+                fontbuffer=subset_bytes,
             )
+            remaining_height = page.insert_textbox(
+                rectangle,
+                replacement,
+                fontname=font_resource_name,
+                fontsize=font_size,
+                color=(0, 0, 0),
+            )
+            if remaining_height < 0:
+                raise ValueError(
+                    "replacement 无法放入 rect；请扩大矩形或减小 --font-size"
+                )
 
-        embedded_font = document.extract_font(font_xref)[-1]
-        if hashlib.sha256(embedded_font).hexdigest() != font_evidence[
-            "font_subset_sha256"
-        ]:
-            raise RuntimeError("嵌入的修复字体与已验证子集哈希不一致")
+            embedded_font = document.extract_font(font_xref)[-1]
+            if hashlib.sha256(embedded_font).hexdigest() != font_evidence[
+                "font_subset_sha256"
+            ]:
+                raise RuntimeError("嵌入的修复字体与已验证子集哈希不一致")
         document.save(candidate, garbage=4, deflate=True)
     finally:
         document.close()
@@ -1234,18 +1253,22 @@ def apply_text_repair(
     page_number: int,
     rectangle: tuple[float, float, float, float],
     replacement: str,
-    font_file: Path,
-    font_size: float,
+    font_file: Path | None,
+    font_size: float | None,
     description: str,
 ) -> Path:
     """在一个明确矩形内受控替换文字，并强制重新执行机器与人工 QA。"""
 
-    if not replacement.strip():
-        raise ValueError("replacement 不能为空")
+    removal_only = replacement == ""
+    if not removal_only and not replacement.strip():
+        raise ValueError("replacement 不能只包含空白字符")
     if not description.strip():
         raise ValueError("description 不能为空")
-    if not math.isfinite(font_size) or font_size <= 0:
-        raise ValueError("font-size 必须是有限且大于 0 的数值")
+    if not removal_only:
+        if font_file is None or font_size is None:
+            raise ValueError("非空 replacement 必须提供 font-file 和 font-size")
+        if not math.isfinite(font_size) or font_size <= 0:
+            raise ValueError("font-size 必须是有限且大于 0 的数值")
 
     root = run_dir.expanduser().resolve()
     manifest = load_manifest(root)
@@ -1256,8 +1279,8 @@ def apply_text_repair(
         )
     _verify_source_pdf(manifest)
     rendered = _verify_rendered_pdf(manifest)
-    resolved_font = font_file.expanduser().resolve()
-    if not resolved_font.is_file():
+    resolved_font = font_file.expanduser().resolve() if font_file else None
+    if resolved_font is not None and not resolved_font.is_file():
         raise FileNotFoundError(f"font-file 不存在：{resolved_font}")
 
     repair_rectangle = fitz.Rect(rectangle)
@@ -1302,7 +1325,7 @@ def apply_text_repair(
             history.append(
                 {
                     "applied_at": _utc_now(),
-                    "type": "text-overlay",
+                    "type": "text-removal" if removal_only else "text-overlay",
                     "description": description.strip(),
                     "page": page_number,
                     "rect": [round(float(value), 3) for value in repair_rectangle],

--- a/tests/test_chatgpt_web.py
+++ b/tests/test_chatgpt_web.py
@@ -94,6 +94,8 @@ class ChatGPTWebBridgeTest(unittest.TestCase):
                 encoding="utf-8"
             )
             self.assertIn("普通 **Chat** 模式", prompt)
+            self.assertIn("一个且仅一个 `json` 代码块", prompt)
+            self.assertIn("代码块的“复制”按钮", prompt)
             self.assertIn(str(exported["batches"][0]["batch_sha256"]), prompt)
             manifest = load_manifest(run_dir)
             self.assertTrue(manifest["chatgpt_web_batch_manifest_sha256"])

--- a/tests/test_chatgpt_web.py
+++ b/tests/test_chatgpt_web.py
@@ -1,0 +1,190 @@
+"""ChatGPT 网页人工桥接只交换文件，不联网也不读取浏览器登录态。"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from reportlab.pdfgen import canvas
+
+from paperlocale.chatgpt_web import (
+    export_chatgpt_web_batches,
+    import_chatgpt_web_responses,
+)
+from paperlocale.contracts import read_jsonl, segment_id, write_jsonl_atomic
+from paperlocale.domains import load_domain_pack
+from paperlocale.workflow import (
+    confirm_reference_run,
+    initialize_run,
+    load_manifest,
+    save_manifest,
+)
+
+
+class ChatGPTWebBridgeTest(unittest.TestCase):
+    def _make_collected_run(self, root: Path, sources: list[str]) -> Path:
+        """建立真实可读 PDF 与手工收集片段，保留安全审查所需的可见文本。"""
+
+        source_pdf = root / "source.pdf"
+        document = canvas.Canvas(str(source_pdf))
+        for index, source in enumerate(sources):
+            document.drawString(40, 760 - index * 24, source)
+        document.save()
+
+        run_dir = root / "run"
+        initialize_run(
+            source_pdf=source_pdf,
+            run_dir=run_dir,
+            source_language="en",
+            target_language="zh-CN",
+        )
+        manifest = load_manifest(run_dir)
+        write_jsonl_atomic(
+            Path(str(manifest["segments_path"])),
+            [{"id": segment_id(source), "source": source} for source in sources],
+        )
+        manifest["segment_count"] = len(sources)
+        manifest["status"] = "collected"
+        save_manifest(run_dir, manifest)
+        confirm_reference_run(
+            run_dir,
+            additional_segment_ids=[],
+            confirmed_by="test reviewer",
+        )
+        return run_dir
+
+    @staticmethod
+    def _write_response(
+        batch: dict[str, object],
+        targets: dict[str, str],
+    ) -> None:
+        """按导出清单写入网页回复，测试与真实人工保存使用同一格式。"""
+
+        response = {
+            "batch_id": batch["batch_id"],
+            "batch_sha256": batch["batch_sha256"],
+            "translations": [
+                {"id": sid, "target": targets[str(sid)]}
+                for sid in batch["segment_ids"]
+            ],
+        }
+        Path(str(batch["response"])).write_text(
+            json.dumps(response, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    def test_export_binds_prompts_and_does_not_touch_browser(self) -> None:
+        """导出必须生成稳定批次和人工说明，不能包含任何网页登录实现。"""
+
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = self._make_collected_run(
+                Path(directory),
+                ["Soil moisture was 10 mm."],
+            )
+            exported = export_chatgpt_web_batches(
+                run_dir=run_dir,
+                domain=domain,
+            )
+            self.assertEqual(exported["provider"], "chatgpt-web-manual")
+            self.assertEqual(exported["batch_count"], 1)
+            prompt = Path(str(exported["batches"][0]["prompt"])).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("普通 **Chat** 模式", prompt)
+            self.assertIn(str(exported["batches"][0]["batch_sha256"]), prompt)
+            manifest = load_manifest(run_dir)
+            self.assertTrue(manifest["chatgpt_web_batch_manifest_sha256"])
+            self.assertEqual(manifest["status"], "collected")
+
+    def test_import_resumes_after_missing_later_batch(self) -> None:
+        """缺少后续网页回复时保留已通过译文，补齐后只处理剩余片段。"""
+
+        sources = [
+            "Soil moisture was 10 mm.",
+            "Air temperature was 20 °C.",
+        ]
+        targets = {
+            segment_id(sources[0]): "土壤湿度为10 mm。",
+            segment_id(sources[1]): "气温为20 °C。",
+        }
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = self._make_collected_run(Path(directory), sources)
+            exported = export_chatgpt_web_batches(
+                run_dir=run_dir,
+                domain=domain,
+                max_segments=1,
+            )
+            first, second = exported["batches"]
+            self._write_response(first, targets)
+
+            with self.assertRaisesRegex(ValueError, "缺少覆盖当前片段"):
+                import_chatgpt_web_responses(
+                    run_dir=run_dir,
+                    domain=domain,
+                    model_label="ChatGPT test model",
+                )
+            self.assertEqual(len(read_jsonl(run_dir / "translations.jsonl")), 1)
+            self.assertEqual(load_manifest(run_dir)["status"], "collected")
+
+            self._write_response(second, targets)
+            self.assertEqual(
+                import_chatgpt_web_responses(
+                    run_dir=run_dir,
+                    domain=domain,
+                    model_label="ChatGPT test model",
+                ),
+                (1, 1),
+            )
+            manifest = load_manifest(run_dir)
+            self.assertEqual(manifest["status"], "translated")
+            self.assertEqual(
+                manifest["translation_provider"],
+                {
+                    "provider": "chatgpt-web-manual",
+                    "model": "ChatGPT test model",
+                    "interface_mode": "manual-copy-paste",
+                    "browser_automation": False,
+                    "batch_manifest_sha256": manifest[
+                        "chatgpt_web_batch_manifest_sha256"
+                    ],
+                },
+            )
+            history = read_jsonl(run_dir / "chatgpt_web" / "import_history.jsonl")
+            self.assertEqual([row["outcome"] for row in history], ["failed", "completed"])
+            self.assertEqual(len(list((run_dir / "chatgpt_web" / "imports").glob("*.json"))), 2)
+
+    def test_import_rejects_wrong_batch_hash_before_writing_translations(self) -> None:
+        """回复若不是针对当前提示批次，不能靠正确片段 ID 绕过身份校验。"""
+
+        source = "Soil moisture was 10 mm."
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = self._make_collected_run(Path(directory), [source])
+            exported = export_chatgpt_web_batches(run_dir=run_dir, domain=domain)
+            batch = exported["batches"][0]
+            response = {
+                "batch_id": batch["batch_id"],
+                "batch_sha256": "0" * 64,
+                "translations": [
+                    {"id": segment_id(source), "target": "土壤湿度为10 mm。"}
+                ],
+            }
+            Path(str(batch["response"])).write_text(
+                json.dumps(response, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "batch_sha256 不匹配"):
+                import_chatgpt_web_responses(
+                    run_dir=run_dir,
+                    domain=domain,
+                    model_label="ChatGPT test model",
+                )
+            self.assertFalse((run_dir / "translations.jsonl").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ from paperlocale.cli import _initialize_or_load_run, _provider_from_args, build_
 
 
 class CliTest(unittest.TestCase):
-    def test_package_version_matches_v033_release_line(self) -> None:
-        self.assertEqual(__version__, "0.3.3")
+    def test_package_version_matches_v040_candidate_line(self) -> None:
+        self.assertEqual(__version__, "0.4.0")
 
     def test_run_parser_accepts_single_command_workflow_options(self) -> None:
         """一键命令必须同时接收源 PDF、运行目录和明确 Provider。"""
@@ -78,6 +78,19 @@ class CliTest(unittest.TestCase):
         self.assertEqual(args.segment_id, ["formula-id"])
         self.assertEqual(args.reason, "pure formula")
         self.assertEqual(args.confirmed_by, "reviewer")
+
+    def test_chatgpt_web_commands_require_explicit_model_label_on_import(self) -> None:
+        """网页桥接使用独立导出/导入命令，不能冒充自动 API Provider。"""
+
+        exported = build_parser().parse_args(
+            ["chatgpt-web-export", "--run-dir", "run"]
+        )
+        self.assertEqual(exported.command, "chatgpt-web-export")
+        self.assertEqual(exported.max_segments, 20)
+        with self.assertRaises(SystemExit):
+            build_parser().parse_args(
+                ["chatgpt-web-import", "--run-dir", "run"]
+            )
 
     def test_apply_text_repair_requires_explicit_geometry_and_font(self) -> None:
         """文字覆盖不得猜测页码、矩形、字体或字号。"""

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -64,6 +64,17 @@ class TranslationContractTest(unittest.TestCase):
         self.assertEqual(protected_counts(source)["number"], {"1960": 1})
         self.assertEqual(validate_translation(source, target), [])
 
+    def test_citation_numbers_attached_to_english_and_chinese_are_equivalent(self) -> None:
+        """英文论文引文号常紧贴单词，中文译文也可紧贴汉字。"""
+
+        source = "Vegetation productivity3,17,18 follows earlier studies24,25."
+        target = "植被生产力3,17,18与早期研究24,25的结果一致。"
+        self.assertEqual(
+            protected_counts(source)["number"],
+            protected_counts(target)["number"],
+        )
+        self.assertEqual(validate_translation(source, target), [])
+
     def test_atomic_jsonl_and_file_closure(self) -> None:
         source = "Soil moisture was 10 mm."
         sid = segment_id(source)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -908,6 +908,34 @@ class WorkflowTest(unittest.TestCase):
             )
             self.assertEqual(list(run_dir.glob(".text-repair-*.pdf")), [])
 
+    def test_apply_text_repair_can_remove_a_bound_fragment_without_font(self) -> None:
+        """只删除模式必须严格限定矩形，且不嵌入空字体子集。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run_dir, rendered, rectangle, _font_file = self._make_text_repair_run(root)
+            apply_text_repair(
+                run_dir,
+                page_number=1,
+                rectangle=rectangle,
+                replacement="",
+                font_file=None,
+                font_size=None,
+                description="删除跨对象残留文字",
+            )
+
+            repaired = fitz.open(rendered)
+            try:
+                text = repaired[0].get_text()
+            finally:
+                repaired.close()
+            history = load_manifest(run_dir)["repair_history"][0]
+            self.assertNotIn("broken caption", text)
+            self.assertIn("Stable outside text 10 mm", text)
+            self.assertEqual(history["type"], "text-removal")
+            self.assertIsNone(history["font_file"])
+            self.assertEqual(history["font_program_bytes_after_subset"], 0)
+
     def test_apply_text_repair_uses_distinct_subsets_across_repairs(self) -> None:
         """同一字体的连续修复必须为新增字形建立不同资源，不能复用缺字子集。"""
 


### PR DESCRIPTION
## Summary

- add a hash-bound manual ChatGPT Web export/import bridge without browser automation
- preserve auditable response snapshots, resumable imports, content contracts, reference handling, PDF rebuild, and QA gates
- integrate the published v0.3.4 Qwen-MT baseline and retain both workflows
- prepare the unreleased v0.4.0 package and release evidence

## Verification

- Python 3.12: 94/94 unit tests passed
- package wheel built and installed successfully
- `git diff --check` passed

No source PDF, translated paper, private ChatGPT link, login state, cookie, or API key is included.