### PR TITLE
docs: record verified v0.4.0 publication

### DIFF
--- a/docs/PYPI_PUBLISHING.zh-CN.md
+++ b/docs/PYPI_PUBLISHING.zh-CN.md
@@ -1,7 +1,7 @@
 # PyPI 可信发布操作手册
 
-状态：`v0.3.2`、`v0.3.3` 与 `v0.3.4` 已通过 PyPI Trusted Publishing 发布；
-当前最新版 `v0.3.4` 已完成公开 attestation、哈希、隔离安装和 `[layout]` 依赖求解
+状态：`v0.3.2`、`v0.3.3`、`v0.3.4` 与 `v0.4.0` 已通过 PyPI Trusted Publishing 发布；
+当前最新版 `v0.4.0` 已完成公开 attestation、哈希、隔离安装和 `[layout]` 依赖求解
 核验。
 
 ## 设计边界
@@ -90,11 +90,29 @@ publisher；任一字段不一致都会被 PyPI 拒绝。
 - 全新 Python 3.12 环境从 PyPI 禁用缓存安装确切 0.3.4 后，模块/发行/CLI
   版本、`pip check`、Qwen-MT Provider 导入和 `domain-check` 全部通过。
 
+## v0.4.0 后续发布证据
+
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32644709628)
+  从稳定提交 `951993d` 构建并安装确切 wheel，版本一致性、`twine check`、
+  领域包和 `[layout]` 求解全部通过；
+- [GitHub v0.4.0 Release](https://github.com/hazugi2004/paperlocale/releases/tag/v0.4.0)
+  的 wheel SHA-256 为
+  `17206e70844ec3e37c3d021923b3a075614af2ad2f1b4aa6d78fe62920f560d9`，
+  sdist 为
+  `ae31f42a6631fbdd1c37b02ab8f605adfd99fc6809f5a445e029f5e232b50021`；
+- [PyPI 发布运行](https://github.com/hazugi2004/paperlocale/actions/runs/32644879147)
+  的准备和发布作业均成功，PyPI 两个文件与 GitHub Release 哈希完全一致；
+- 两个 PyPI Integrity API provenance 均绑定仓库 `hazugi2004/paperlocale`、工作流
+  `publish-pypi.yml` 和 Environment `pypi`；`pypi-attestations==0.0.30`
+  验证 wheel 和 sdist 均返回 `OK`；
+- 全新 Python 3.12 环境从 PyPI 禁用缓存安装确切 0.4.0 后，模块/发行/CLI
+  版本、`pip check`、领域包、ChatGPT Web 命令入口与 `[layout]` 求解全部通过。
+
 ## 后续版本操作
 
 1. 在 GitHub Actions 打开 `publish-pypi`，选择 `Run workflow`。
 2. 输入已经公开并完成审计、且尚未上传 PyPI 的稳定标签；PyPI 版本不可覆盖，
-   不要再次发布 `v0.3.2`、`v0.3.3` 或 `v0.3.4`。
+   不要再次发布 `v0.3.2`、`v0.3.3`、`v0.3.4` 或 `v0.4.0`。
 3. 等待 `Verify published distributions` 通过。
 4. 在 `pypi` Environment 部署审批中复核标签并手动批准。
 5. 发布作业成功后，检查 `https://pypi.org/project/paperlocale/` 的版本、文件和

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,7 +65,7 @@
 - [x] 贡献指南、Issue/PR 模板与标签构建工作流
 - [x] Contributor Covenant 3.0 社区准则与 `CITATION.cff` 学术引用元数据
 - [x] 仅手动触发、OIDC 最小权限且复用已审计 Release 附件的 PyPI 可信发布工作流
-- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2`、`v0.3.3` 和 `v0.3.4`
+- [x] 通过 Trusted Publishing 与数字 attestation 发布 PyPI `v0.3.2`、`v0.3.3`、`v0.3.4` 和 `v0.4.0`
 - [x] GitHub `v0.1.0` Release
 - [x] GitHub `v0.2.0` 一键运行、结构门禁与 Provider 评估 Release
 - [x] GitHub `v0.3.0` 真实试运行反向校准、参考文献审计与恢复语义 Release
@@ -73,6 +73,7 @@
 - [x] GitHub `v0.3.2` 行号参考文献、人工透传、碎词安全审查与 schema 4 Release
 - [x] GitHub `v0.3.3` 受控文字修复、独立字体子集与 74 项测试 Release
 - [x] GitHub `v0.3.4` Qwen-MT 泛化、单片段检查点、参考文献行识别与 88 项测试 Release
+- [x] GitHub `v0.4.0` ChatGPT Web 人工桥接、受控文字删除与 94 项测试 Release
 - [x] 三个有验收标准的 good first issues
 - [x] 自有合成论文的原文、译文与全页 QA 演示 GIF
 

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -49,3 +49,25 @@ v0.4.0 增加 ChatGPT 网页端普通 Chat 的人工、可审计文件桥接。�
 
 上述运行不把源 PDF、完整译本或私人 ChatGPT 会话链接提交到仓库。
 这是维护者主导的真实运行证据，不等同于非维护者的外部采用证据。
+
+## 公开发行
+
+- [实现 PR #32](https://github.com/hazugi2004/paperlocale/pull/32) 与
+  [发布准备 PR #33](https://github.com/hazugi2004/paperlocale/pull/33) 的
+  Python 3.10–3.13、macOS 非 editable 中文/空格路径和 `[layout]` 求解通过；
+- [标签构建](https://github.com/hazugi2004/paperlocale/actions/runs/32644709628)
+  成功，[GitHub v0.4.0](https://github.com/hazugi2004/paperlocale/releases/tag/v0.4.0)
+  已设为 latest；
+- wheel SHA-256 为
+  `17206e70844ec3e37c3d021923b3a075614af2ad2f1b4aa6d78fe62920f560d9`，
+  sdist 为
+  `ae31f42a6631fbdd1c37b02ab8f605adfd99fc6809f5a445e029f5e232b50021`；
+- [PyPI 0.4.0](https://pypi.org/project/paperlocale/0.4.0/) 由
+  [Trusted Publishing 运行](https://github.com/hazugi2004/paperlocale/actions/runs/32644879147)
+  从上述确切 GitHub Release 附件发布，两处文件哈希完全一致；
+- PyPI Integrity API 的 wheel 与 sdist provenance 均绑定仓库
+  `hazugi2004/paperlocale`、工作流 `publish-pypi.yml` 和 Environment `pypi`；
+  `pypi-attestations==0.0.30` 密码学验证均返回 `OK`；
+- 全新 Python 3.12 环境禁用 pip 缓存后从 PyPI 安装确切 0.4.0，
+  模块/发行/CLI 版本、`pip check`、领域包、ChatGPT Web 命令入口与
+  `[layout]` 求解全部通过。


### PR DESCRIPTION
## Verified publication evidence

- record the successful v0.4.0 tag build and Trusted Publishing run
- record exact GitHub/PyPI wheel and sdist SHA-256 values
- record Integrity API publisher identity and successful PEP 740 verification
- record the clean Python 3.12 PyPI install, CLI, domain, and layout checks

This PR changes documentation only.