### PR TITLE
PaperLocale v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 本项目遵循语义化版本。未发布内容先进入 `Unreleased`。
 
+## 0.4.2 - 2026-08-28
+
+### Added
+
+- `paperlocale run --unattended` 可在单条非交互命令中自动完成确定性
+  参考文献映射、版面安全透传、全文翻译、内容门禁、PDF 重建与全页
+  机器 QA；成功后直接打印完整候选 PDF 路径；
+- 无人值守决定以 `paperlocale-unattended` 身份和明确原因写入哈希
+  绑定映射，运行清单记录自动参考文献与透传数量，不冒充人工复核；
+- 新增 `restore-source-vectors`，先以源/译哈希绑定当前机器 QA，再只在
+  `source_vector_drawings > translated_vector_drawings` 的页面重放按
+  0.01 PDF 点边界确认缺失的源矢量路径，复用现有文字、页面、图片、
+  备份和修复历史门禁；
+- `apply-text-repair --single-line` 可按子集字体的实际宽度、升部与降部
+  在浅矩形中写入一行，容量超界仍在修改 PDF 前拒绝；
+- 新增 `rollback-last-repair`，只允许从 `repair_history` 链尾按
+  after/before 哈希和绑定备份逆向恢复，将回滚项移入
+  `repair_rollback_history`，并清除已过期的 QA/人工验收绑定。
+
+### Changed
+
+- Provider 首轮译文未通过内容合同时，用同一 Provider 传入原候选与
+  具体错误定向修复一次；合格片段继续原子保存，两次失败证据保留在
+  `rejected_translations.jsonl`；
+- Qwen-MT 继续保持单片段调用边界，对真实运行中观察到的临时连接断开
+  做有界重试，HTTP 业务错误仍立即失败。
+
+### Fixed
+
+- 修正真实论文中全大写章节词、国家/地址缩写、非 ASCII 单词中单位
+  误匹配、术语左边界与期刊艺术字大小写造成的内容合同误拒绝；
+- 断点续跑不再因为 Codex CLI 补丁版本变化而拒绝同一
+  `codex-local` 模型与推理强度；新旧 CLI 版本和切换前译文数量保存在
+  `translation_provider_history`，Provider、模型或推理强度变化仍明确失败。
+
+### Safety boundary
+
+- `--unattended` 只自动采用确定性算法结果，不把普通翻译失败静默改为
+  透传，不自动执行 `accept`；无人值守候选仍如实标记为 `qa_generated`。
+
 ## 0.4.1 - 2026-08-23
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,10 +5,10 @@ type: software
 authors:
   - name: "PaperLocale contributors"
 abstract: "PaperLocale is an auditable workflow for translating academic PDFs while preserving page structure, figures, tables, formulas, protected scientific information, and human-reviewed quality evidence."
-version: "0.4.1"
-date-released: "2026-08-23"
+version: "0.4.2"
+date-released: "2026-08-28"
 repository-code: "https://github.com/hazugi2004/paperlocale"
-repository-artifact: "https://github.com/hazugi2004/paperlocale/releases/tag/v0.4.1"
+repository-artifact: "https://github.com/hazugi2004/paperlocale/releases/tag/v0.4.2"
 license: AGPL-3.0-only
 keywords:
   - academic PDF

--- a/README.md
+++ b/README.md
@@ -74,22 +74,58 @@ every candidate remains marked for manual domain review.
 ## Install
 
 Python 3.10–3.13 and Poppler's `pdftoppm` are required for the complete workflow.
-PaperLocale 0.4.1 is published on PyPI through attested Trusted Publishing.
-The audited maintainer procedure and release evidence are documented in
+Stable PaperLocale releases are published on PyPI through attested Trusted
+Publishing. The audited maintainer procedure and release evidence are documented in
 [docs/PYPI_PUBLISHING.zh-CN.md](docs/PYPI_PUBLISHING.zh-CN.md).
+PaperLocale 0.4.2 adds `--unattended` and the audited repair commands documented
+below. To run this checkout, use the normal non-editable install path
+`python -m pip install ".[layout]"`.
 The v0.4.0 manual ChatGPT Web bridge is documented in
 [docs/CHATGPT_WEB_MANUAL.zh-CN.md](docs/CHATGPT_WEB_MANUAL.zh-CN.md) for its
 copy/paste workflow and usage-limit boundary.
 
+After v0.4.2 is published, install the exact public release with:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install "paperlocale[layout]==0.4.1"
+python -m pip install "paperlocale[layout]==0.4.2"
 paperlocale --version
 paperlocale domain-check atmospheric-science
 ```
 
 ## Quick start
+
+For a single non-interactive command that produces a complete candidate PDF,
+use `--unattended`. The `codex-local` provider invokes structured
+`codex exec --ephemeral` in the background; it does not open or wait for a Codex
+conversation window:
+
+```bash
+paperlocale run paper.pdf --run-dir runs/paper \
+  --provider codex-local \
+  --model gpt-5.6-sol \
+  --reasoning-effort high \
+  --domain atmospheric-science \
+  --unattended
+```
+
+The command automatically adopts only deterministic reference matches and
+deterministic layout-safety passthroughs, then translates, validates, rebuilds,
+and generates all-page machine QA. On success it prints the exact candidate PDF
+path under `runs/paper/render_output/`. References remain unchanged under the
+default `preserve` policy, and unsafe split layout objects remain byte-for-byte
+unchanged with an audit record. A "complete candidate PDF" therefore means that
+all pages and collected segments are closed, not that formulas, references, or
+unsafe fragments are forcibly converted to Chinese.
+
+Unattended mode does not fabricate human visual acceptance: the final state is
+still `qa_generated`. Provider, content-contract, or machine-QA failures exit
+with an explicit error and retain valid checkpoints; rerun the same command to
+resume. PaperLocale never silently switches providers.
+
+The supervised workflow remains available when reference boundaries should be
+reviewed manually:
 
 Use the same resumable command to initialize the run, collect layout segments,
 translate, validate, rebuild, and generate all-page QA:
@@ -170,13 +206,26 @@ paragraph. The object-level fix is proposed upstream in
 not carry a local PDF overlay workaround while that review is pending.
 
 The schema 4 run manifest binds the domain-pack content hash, provider, model,
-reasoning effort, Codex CLI version, collect/render layout-engine versions, and
-any human-confirmed passthrough map. A Codex run therefore requires an explicit
+reasoning effort, Codex CLI version history, collect/render layout-engine versions,
+and any human-confirmed passthrough map. A Codex run therefore requires an explicit
 `--model`.
 
 When vector objects disappear, QA records their page, bounding box, and area,
-and draws red boxes at the expected locations in both comparison panels. Import
-an independently repaired candidate through the audited path:
+and draws red boxes at the expected locations in both comparison panels. When
+the original source paths should remain at those locations, replay only the
+exactly missing paths through PaperLocale's controlled command:
+
+```bash
+paperlocale restore-source-vectors --run-dir runs/paper \
+  --description "Restore source vectors confirmed missing by machine QA"
+```
+
+The command requires a current QA report whose source and translated hashes
+match the manifest. It only inspects pages where QA records
+`source_vector_drawings > translated_vector_drawings`, matches missing paths at
+0.01 PDF-point precision, rejects text, page-geometry, or image changes, backs
+up the candidate, and records `repair_history`. Other independently repaired
+candidates can still use the audited import path:
 
 ```bash
 paperlocale apply-vector-repair --run-dir runs/paper \
@@ -198,6 +247,7 @@ paperlocale apply-text-repair --run-dir runs/paper \
   --replacement "Figure 5 corrected caption" \
   --font-file /path/to/NotoSansCJKsc-Regular.otf \
   --font-size 9.5 \
+  --single-line \
   --description "Repair a split-token figure caption"
 ```
 
@@ -210,7 +260,9 @@ geometry, PDF hashes, and backup in `repair_history`. QA and human acceptance
 must then run again. Use a locally licensed font and do not commit it to the
 repository; a TTF/OTF usually produces cleaner extraction metadata than a font
 collection, but every result still goes through the same QA warnings and visual
-review.
+review. `--single-line` measures the subset font's actual width, ascender, and
+descender and rejects a shallow rectangle before modification if the line does
+not fit; omit it when normal textbox wrapping is intended.
 
 For a reviewed fragment that must only be removed, pass an explicit empty
 replacement and omit the font options:
@@ -225,6 +277,19 @@ Removal mode embeds no font, records `text-removal` in `repair_history`, and
 still enforces the same rectangle, outside-text, page, image, link, vector,
 backup, QA, and human-acceptance gates. Whitespace-only replacements are
 rejected.
+
+Every recorded PDF repair can be reversed from the current chain tail only:
+
+```bash
+paperlocale rollback-last-repair --run-dir runs/paper \
+  --reason "Remove the last audited repair before rebuilding QA"
+```
+
+The command requires the current PDF to match the tail `after_sha256` and its
+backup to match `before_sha256`. It restores that exact backup, moves the entry
+from `repair_history` to `repair_rollback_history`, returns the run to
+`rendered`, and invalidates the old QA and visual-acceptance binding. It cannot
+skip newer repairs; run machine QA and full visual review again after rollback.
 
 For a BYOK OpenAI-compatible endpoint:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,15 +58,19 @@ paperlocale provider-eval \
 ## 安装
 
 需要 Python 3.10–3.13。完整 PDF 流程还需要 Poppler 的 `pdftoppm`：macOS 可执行 `brew install poppler`，Ubuntu 可执行 `sudo apt-get install poppler-utils`。
-PaperLocale 0.4.1 已通过带数字 attestation 的 Trusted Publishing 发布到 PyPI；
+PaperLocale 稳定版本通过带数字 attestation 的 Trusted Publishing 发布到 PyPI；
 维护者发布流程与公开核验证据见 [PyPI 发布手册](docs/PYPI_PUBLISHING.zh-CN.md)。
+PaperLocale 0.4.2 增加下文所述的 `--unattended` 与可审计修复命令；运行
+当前检出请使用普通非 editable 安装：`python -m pip install ".[layout]"`。
 v0.4.0 网页桥接的操作与额度边界见
 [ChatGPT 网页端人工翻译桥接](docs/CHATGPT_WEB_MANUAL.zh-CN.md)。
+
+v0.4.2 发布后，可按以下方式安装精确公开版本：
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install "paperlocale[layout]==0.4.1"
+python -m pip install "paperlocale[layout]==0.4.2"
 paperlocale --version
 paperlocale domain-check atmospheric-science
 ```
@@ -74,6 +78,34 @@ paperlocale domain-check atmospheric-science
 当前验证兼容 `pdf2zh-next 2.9.0`。版面依赖较多，所以被放在可选的 `layout` 依赖组中。
 
 ## 开始翻译
+
+如果希望输入一条命令后直接得到整篇候选 PDF，使用 `--unattended`。
+`codex-local` 会在后台调用结构化的 `codex exec --ephemeral`，不打开、
+不等待任何 Codex 对话窗口：
+
+```bash
+codex login
+paperlocale run paper.pdf \
+  --run-dir runs/paper \
+  --provider codex-local \
+  --model gpt-5.6-sol \
+  --reasoning-effort high \
+  --domain atmospheric-science \
+  --unattended
+```
+
+命令会连续完成初始化、片段收集、确定性参考文献映射、必要的版面
+安全透传、全文翻译、内容门禁、PDF 重建和全页机器 QA。成功后直接
+打印 `runs/paper/render_output/` 中候选 PDF 的精确路径。默认
+`preserve` 策略仍保留参考文献；被确定性判定为不能安全独立翻译的
+碎片也会原样保留并在清单中留痕。因此“完整候选 PDF”表示所有页面和
+片段都已闭合，不表示参考文献、公式或碎片会被强行改成中文。
+
+`--unattended` 不把机器 QA 伪装成人工逐页验收，运行状态仍是
+`qa_generated`。如果 Provider、内容合同或机器 QA 失败，命令会明确退出并
+保留已通过的断点；重新执行同一条命令即可续跑，不会静默切换 Provider。
+
+以下是需要人工复核参考文献边界的受监督模式。
 
 使用同一条可断点续跑命令推进初始化、片段收集、翻译、内容门禁、PDF 重建和全页 QA。使用本机 Codex 登录态：
 
@@ -180,10 +212,21 @@ paperlocale confirm-passthrough \
 需要上游提供相邻对象上下文或合并能力，不能靠提示词猜测。
 
 schema 4 运行清单会记录 PaperLocale 版本、领域包内容哈希、Provider、模型、推理强度、Codex CLI
-版本、collect/render 使用的版面引擎版本，以及人工透传映射的哈希。`codex-local`
+版本与断点间的 CLI 版本历史、collect/render 使用的版面引擎版本，以及人工透传映射的哈希。`codex-local`
 因此要求显式提供 `--model`；没有填写推理强度时会如实记录为空，不伪造实际设置。
 
-若机器 QA 报告矢量对象减少，报告会列出缺失对象的页码、边界框和面积，并在对照图两侧用红框标出位置。完成独立文件形式的矢量修复后，使用受控导入命令：
+若机器 QA 报告矢量对象减少，报告会列出缺失对象的页码、边界框和面积，并在对照图两侧用红框标出位置。若这些位置应保留源 PDF 的原始路径，可使用 PaperLocale 内置的受控重放：
+
+```bash
+paperlocale restore-source-vectors \
+  --run-dir runs/paper \
+  --description "恢复机器 QA 确认缺失的源矢量路径"
+```
+
+该命令要求当前 QA 报告的源/译哈希与 manifest 一致，并且只检查 QA 中
+`source_vector_drawings > translated_vector_drawings` 的页面；随后仅重放按
+0.01 PDF 点边界缺失的源路径，仍拒绝文字、页尺寸或图片变化，备份原候选并
+写入 `repair_history`。完成独立文件形式的其他矢量修复后，仍可使用受控导入命令：
 
 ```bash
 paperlocale apply-vector-repair \
@@ -205,6 +248,7 @@ paperlocale apply-text-repair \
   --replacement "图5 农业干旱评估" \
   --font-file /path/to/NotoSansCJKsc-Regular.otf \
   --font-size 9.5 \
+  --single-line \
   --description "修复跨对象碎裂图注"
 ```
 
@@ -214,7 +258,8 @@ paperlocale apply-text-repair \
 字体程序；清单记录原字体与子集哈希、子集前后字节、修复前后文字、矩形、PDF 哈希
 和旧 PDF 备份。完成后仍必须重新执行 `qa` 和 `accept`。字体须由用户在本机合法
 取得，不能提交到仓库；TTF/OTF 通常比字体集合产生更干净的抽取元数据，但任何
-CMap 警告和最终视觉效果仍由同一 QA 流程检查。
+CMap 警告和最终视觉效果仍由同一 QA 流程检查。`--single-line` 会按子集字体
+实际宽度、升部和降部验证一行能否放入浅矩形；若不应禁止自动换行，则不要传入该参数。
 
 若损坏对象只是已确认的孤立残片（例如固定首字母与可译对象切分后遗留
 `limate`），可显式传入空 replacement：
@@ -230,6 +275,19 @@ paperlocale apply-text-repair \
 
 只删除模式不需要 `--font-file` 或 `--font-size`，不会嵌入空字体子集；
 清单以 `text-removal` 独立记录。只包含空格的 replacement 仍会被拒绝。
+
+所有已记录的 PDF 修复都只能从当前修复链尾逆序回滚：
+
+```bash
+paperlocale rollback-last-repair \
+  --run-dir runs/paper \
+  --reason "移除最后一次审计修复并重新生成 QA"
+```
+
+命令要求当前 PDF 匹配链尾 `after_sha256`，绑定备份匹配 `before_sha256`；
+恢复后把该项从 `repair_history` 移入 `repair_rollback_history`，将运行退回
+`rendered`，并解除旧 QA 与人工验收绑定。它不能跳过更新的修复；回滚后必须
+重新执行机器 QA 和完整逐页视觉验收。
 
 需要逐阶段控制时，仍可使用同一生产路径的 `init-run -> collect -> reference-review/confirm-references -> 可选 confirm-passthrough -> translate -> validate -> render -> qa -> accept` 命令序列。
 
@@ -261,7 +319,7 @@ paperlocale domain-check /path/to/your-domain
 
 ## 当前证据边界
 
-- 97 项单元测试不联网运行，覆盖内容合同、三种 Provider、ChatGPT 网页人工桥接、单片段批处理边界、Provider 评估、一键断点续跑、双栏参考文献空间边界、自动误匹配显式排除、参考文献与透传人工确认映射、碎词安全审查、领域包身份、PDF 哈希绑定、图片/矢量对象门禁、受控文字修复、页面 QA、隔离环境入口和演示产物；
+- 119 项单元测试不联网运行，覆盖内容合同、三种 Provider、ChatGPT 网页人工桥接、单片段批处理边界、Provider 评估、无人值守与受监督断点续跑、Codex CLI 版本漂移审计、受控源矢量重放与链尾回滚、双栏参考文献空间边界、自动误匹配显式排除、参考文献与透传映射、碎词安全审查、领域包身份、PDF 哈希绑定、图片/矢量对象门禁、受控单行/多行文字修复、页面 QA、隔离环境入口和演示产物；
 - 本地已用 `pdf2zh-next 2.9.0` 跑通合成 A4 双栏 PDF 的收集、查表重建和逐页 QA；
 - 版面兼容性夹具包含公式占位、矢量表格与嵌入图片；源文/译文均为 1 个图片对象和 8 次矢量绘制；
 - v0.3.3 两页中文文字修复夹具将 23,278,008 字节原始字体独立子集化为 22,912 字节，最终 PDF 为 19,594 字节；机器 QA 为 0 errors / 0 warnings，并已逐页视觉验收。两类夹具均为项目自有，不提交任何受版权限制的论文；

--- a/docs/releases/v0.4.2.md
+++ b/docs/releases/v0.4.2.md
@@ -1,0 +1,43 @@
+# PaperLocale v0.4.2
+
+v0.4.2 将真实整篇论文试运行中已经验证的断点恢复、内容合同和 PDF 修复边界
+收敛为公开命令。它仍沿用 `collect -> translate -> validate -> render -> qa ->
+accept` 生产路径，不把机器 QA 冒充人工视觉验收。
+
+## 无人值守完整候选
+
+- `paperlocale run --unattended` 在单条非交互命令中自动采用确定性参考文献
+  匹配和版面安全透传，随后完成全文翻译、内容门禁、重建和全页机器 QA；
+- 自动决定使用固定审计身份并绑定源 PDF、片段及映射哈希；普通翻译失败不会
+  被静默改成透传，Provider、合同或机器 QA 失败会保留真实断点并明确退出；
+- 成功结果仍是 `qa_generated` 候选，必须逐页视觉检查并显式执行 `accept`。
+
+## 内容合同与断点兼容
+
+- 修正全大写章节词、国家/地址缩写、非 ASCII 单词内单位、术语左边界和期刊
+  艺术字大小写导致的误拒绝，同时继续保护科学缩写、数字、单位和公式；
+- 首轮合同失败只把失败片段、上一候选和具体错误交还同一 Provider 定向修复
+  一次；合格片段原子保存，连续失败保留两轮审计证据；
+- `codex-local` 在 Provider、模型和推理强度不变时允许 Codex CLI 补丁版本
+  漂移，并把实际版本转换写入 `translation_provider_history`；模型或推理强度
+  改变仍明确拒绝续跑。
+
+## 可逆 PDF 修复
+
+- `restore-source-vectors` 要求当前 QA 的源/译哈希与 manifest 一致，只在
+  `source_vector_drawings > translated_vector_drawings` 的页面按 0.01 PDF 点
+  边界重放缺失路径，并继续执行文字、页面、图片、备份和修复历史门禁；
+- `apply-text-repair --single-line` 使用字体子集的实际宽度、升部和降部验证浅
+  矩形中的单行写入，超界时在修改 PDF 前拒绝；
+- `rollback-last-repair` 只允许从 `repair_history` 链尾按 after/before 哈希和
+  绑定备份回滚，将条目移入 `repair_rollback_history`，并解除过期 QA/accept
+  绑定。回滚后必须重新执行机器 QA 和完整逐页视觉验收。
+
+## 验证
+
+- 119 项不联网单元测试通过；
+- 发布门禁要求 Python 3.12 编译与测试、目标 Ruff 检查、`git diff --check`、
+  wheel 与 sdist 构建、`twine check`、精确 wheel 安装、包/CLI 版本一致、
+  领域包检查和 `[layout]` 依赖求解；
+- 无人值守不会自动 `accept`，发布包也不包含任何真实论文、完整译本、模型
+  会话、凭据或本地字体。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paperlocale"
-version = "0.4.1"
+version = "0.4.2"
 description = "Verified, layout-preserving academic PDF translation with pluggable providers and domain packs."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/paperlocale/__init__.py
+++ b/src/paperlocale/__init__.py
@@ -1,3 +1,3 @@
 """PaperLocale：具有科学信息硬门禁的学术 PDF 保版翻译工具。"""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/paperlocale/cli.py
+++ b/src/paperlocale/cli.py
@@ -34,6 +34,8 @@ from .workflow import (
     prepare_reference_review_run,
     qa_run,
     render_run,
+    restore_source_vectors,
+    rollback_last_repair,
     run_to_qa,
     translate_run,
     validate_run,
@@ -141,7 +143,7 @@ def build_parser() -> argparse.ArgumentParser:
     initialize.add_argument("--target-language", default="zh-CN")
     initialize.add_argument("--pages")
 
-    run = subparsers.add_parser("run", help="从当前断点一键推进到机器 QA")
+    run = subparsers.add_parser("run", help="从当前断点推进到完整候选 PDF 和机器 QA")
     run.add_argument("source_pdf", type=Path)
     run.add_argument("--run-dir", type=Path, required=True)
     run.add_argument("--source-language", default="en")
@@ -166,6 +168,14 @@ def build_parser() -> argparse.ArgumentParser:
     run.add_argument("--pdf2zh-bin")
     run.add_argument("--dpi", type=int, default=144)
     run.add_argument("--pdftoppm-bin")
+    run.add_argument(
+        "--unattended",
+        action="store_true",
+        help=(
+            "自动采用确定性参考文献和片段安全结果，"
+            "无人交互地生成完整候选 PDF 与机器 QA"
+        ),
+    )
 
     collect = subparsers.add_parser("collect", help="收集 PDF 待译片段")
     collect.add_argument("--run-dir", type=Path, required=True)
@@ -286,6 +296,20 @@ def build_parser() -> argparse.ArgumentParser:
     repair.add_argument("--repaired-pdf", type=Path, required=True)
     repair.add_argument("--description", required=True)
 
+    source_vector_repair = subparsers.add_parser(
+        "restore-source-vectors",
+        help="重放译文中按精确边界缺失的源 PDF 矢量路径",
+    )
+    source_vector_repair.add_argument("--run-dir", type=Path, required=True)
+    source_vector_repair.add_argument("--description", required=True)
+
+    rollback_repair = subparsers.add_parser(
+        "rollback-last-repair",
+        help="使用 repair_history 绑定备份回滚最后一次 PDF 修复",
+    )
+    rollback_repair.add_argument("--run-dir", type=Path, required=True)
+    rollback_repair.add_argument("--reason", required=True)
+
     text_repair = subparsers.add_parser(
         "apply-text-repair",
         help="在明确页面矩形内替换或删除文字，并记录修复历史",
@@ -319,6 +343,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--font-size",
         type=float,
         help="非空 replacement 必需；只删除模式不使用",
+    )
+    text_repair.add_argument(
+        "--single-line",
+        action="store_true",
+        help="按字体实际宽高在浅矩形中写入一行，不自动换行",
     )
     text_repair.add_argument("--description", required=True)
 
@@ -425,11 +454,18 @@ def main() -> int:
             reference_policy=args.reference_policy,
             max_segments=args.max_segments,
             max_characters=args.max_characters,
+            unattended=args.unattended,
         )
         if final_manifest["status"] == "qa_generated":
             comparisons = Path(str(final_manifest["qa_output_dir"])) / "comparisons"
-            print(f"运行已推进到机器 QA；请逐页检查：{comparisons}")
-            print("确认无误后执行 paperlocale accept，人工验收不会自动完成")
+            rendered_pdf = Path(str(final_manifest["rendered_pdf"]))
+            if args.unattended:
+                print(f"无人值守翻译完成：{rendered_pdf}")
+                print(f"机器 QA 逐页对照：{comparisons}")
+                print("候选 PDF 尚未人工视觉验收；请逐页检查后执行 paperlocale accept")
+            else:
+                print(f"运行已推进到机器 QA；请逐页检查：{comparisons}")
+                print("确认无误后执行 paperlocale accept，人工验收不会自动完成")
         else:
             print(f"运行当前状态：{final_manifest['status']}")
         return 0
@@ -530,6 +566,20 @@ def main() -> int:
         )
         print(f"矢量修复已导入并记录历史：{repaired}；请重新执行 qa 和 accept")
         return 0
+    if args.command == "restore-source-vectors":
+        repaired = restore_source_vectors(
+            args.run_dir,
+            description=args.description,
+        )
+        print(f"缺失源矢量已重放并记录：{repaired}；请重新执行 qa 和 accept")
+        return 0
+    if args.command == "rollback-last-repair":
+        restored = rollback_last_repair(
+            args.run_dir,
+            reason=args.reason,
+        )
+        print(f"最后一次修复已回滚并记录：{restored}；请重新执行 qa")
+        return 0
     if args.command == "apply-text-repair":
         repaired = apply_text_repair(
             args.run_dir,
@@ -539,6 +589,7 @@ def main() -> int:
             font_file=args.font_file,
             font_size=args.font_size,
             description=args.description,
+            single_line=args.single_line,
         )
         print(
             f"文字修复已应用并记录历史：{repaired}；"

--- a/src/paperlocale/contracts.py
+++ b/src/paperlocale/contracts.py
@@ -34,11 +34,96 @@ NUMBER_RE = re.compile(
     r"\d+(?:[.,]\d+)?(?:[eE][-+]?\d+)?"
 )
 ABBREVIATION_RE = re.compile(r"(?<![A-Za-z0-9])(?:[A-Z][A-Z0-9-]{1,})(?![A-Za-z0-9])")
-ABBREVIATION_EXCLUSIONS = frozenset({"ABSTRACT", "KEYWORDS", "REFERENCES"})
+# 真实论文常把章节名、出版元数据和图件标签排成全大写。它们是应翻译的
+# 普通英语词，而不是必须逐字保留的变量缩写。这里只列入批量运行中已经
+# 观察到的明确类别；NDVI、MOE、DH、CO 等科学标记仍继续走硬门禁。
+TRANSLATABLE_UPPERCASE_WORDS = frozenset(
+    {
+        "ABSTRACT",
+        "ACCEPTED",
+        "ACCESS",
+        "AND",
+        "APR",
+        "APRIL",
+        "ARTICLE",
+        "AUG",
+        "AUGUST",
+        "AUTHOR",
+        "AVAILABILITY",
+        "BY",
+        "CITATION",
+        "CONCLUSION",
+        "CONCLUSIONS",
+        "CONTRIBUTIONS",
+        "COPULA-BASED",
+        "COPYRIGHT",
+        "CORRESPONDENCE",
+        "DATA",
+        "DEC",
+        "DECEMBER",
+        "DISCUSSION",
+        "EDITED",
+        "EXTREMES",
+        "FEB",
+        "FEBRUARY",
+        "FIGURE",
+        "FOR",
+        "FUNDING",
+        "INTRODUCTION",
+        "JAN",
+        "JANUARY",
+        "JUL",
+        "JULY",
+        "JUN",
+        "JUNE",
+        "KEYWORDS",
+        "LETTER",
+        "MAR",
+        "MARCH",
+        "MATERIAL",
+        "MATERIALS",
+        "MAY",
+        "METHODS",
+        "MODELLED",
+        "NOV",
+        "NOVEMBER",
+        "OCT",
+        "OCTOBER",
+        "OF",
+        "OPEN",
+        "ORIGINAL",
+        "PATTERNS",
+        "PERMISSIONS",
+        "PRECIPITATION",
+        "PUBLICATION",
+        "PUBLISHED",
+        "RECEIVED",
+        "REFERENCES",
+        "RESEARCH",
+        "RESULTS",
+        "REVISED",
+        "REVIEWED",
+        "SEP",
+        "SEPT",
+        "SEPTEMBER",
+        "SPATIO-TEMPORAL",
+        "STATEMENT",
+        "SUPPLEMENTARY",
+        "TOOLS",
+        "TYPE",
+        "VOL",
+    }
+)
+# 国家缩写在机构地址和普通正文中可自然译为中文国名；继续要求保留其英文
+# 表面形式会把正确的“美国”“英国”误判为信息丢失。
+GEOGRAPHIC_ABBREVIATION_EXCLUSIONS = frozenset({"US", "USA", "UK"})
+ADDRESS_REGION_RE = re.compile(r"\b([A-Z]{2})(?=,\s*USA\b)")
 UNIT_RE = re.compile(
-    r"(?<![A-Za-z])(?:%|°[CF]?|mm|cm|m|km|Pa|hPa|K|W\s*m-?2|"
-    r"g\s*C\s*m-?2(?:\s*d-?1)?|µmol\s*m-?2\s*s-?1)(?![A-Za-z])",
-    re.IGNORECASE,
+    # 边界拒绝与任意非中日韩文字母粘连，避免把 Météorologiques 的 M
+    # 识别成 metre；同时允许中文译文直接写成“10 mm降水”。单位大小写
+    # 具有科学含义，因此不能再对整条正则使用 IGNORECASE。
+    r"(?<![^\W\d_\u3400-\u9fff])(?:%|°[CF]?|mm|cm|m|km|Pa|hPa|K|W\s*m-?2|"
+    r"g\s*C\s*m-?2(?:\s*d-?1)?|µmol\s*m-?2\s*s-?1)(?![^\W\d_\u3400-\u9fff])",
 )
 CJK_RE = re.compile(r"[\u3400-\u9fff]")
 ENGLISH_RE = re.compile(r"[A-Za-z]")
@@ -77,16 +162,28 @@ def protected_counts(text: str) -> dict[str, Counter[str]]:
     # PDF 版面引擎可能在连字符后插入断行空格，例如 ``HDI- MSDI`` 或
     # ``SSP5- 8.5``。缩写门禁只消除这一种版面空格，使正确合并后的译文
     # 仍可通过；原始文字、数字和其他标点检查保持不变。
-    abbreviation_text = re.sub(r"(?<=[a-z])(?=[A-Z]{2})", " ", text)
+    # 只拆分从词首开始的 ``andHDI`` 版面粘连。旧规则会在期刊艺术字
+    # ``ChaNGE`` 内部制造不存在的 ``NGE`` 缩写。
+    abbreviation_text = re.sub(
+        r"(?<![A-Za-z0-9])([a-z]+)(?=[A-Z]{2})",
+        r"\1 ",
+        text,
+    )
     abbreviation_text = re.sub(
         r"(?<=[A-Z0-9])-\s+(?=[A-Z0-9])",
         "-",
         abbreviation_text,
     )
+    address_regions = set(ADDRESS_REGION_RE.findall(abbreviation_text))
+    abbreviation_exclusions = (
+        TRANSLATABLE_UPPERCASE_WORDS
+        | GEOGRAPHIC_ABBREVIATION_EXCLUSIONS
+        | address_regions
+    )
     abbreviations = (
         value
         for value in ABBREVIATION_RE.findall(abbreviation_text)
-        if value not in ABBREVIATION_EXCLUSIONS
+        if value not in abbreviation_exclusions
     )
     return {
         "formula": Counter(FORMULA_RE.findall(text)),
@@ -97,6 +194,18 @@ def protected_counts(text: str) -> dict[str, Counter[str]]:
         "abbreviation": Counter(abbreviations),
         "unit": Counter(match.group(0) for match in UNIT_RE.finditer(text)),
     }
+
+
+def source_term_is_present(text: str, term: str) -> bool:
+    """按左侧词边界判断领域术语是否真实出现。
+
+    术语表使用单数词形时仍允许命中复数，例如 ``event`` 命中
+    ``events``；但 ``temporal resolution`` 不能从 ``spatiotemporal`` 或
+    ``spatio-temporal`` 的词尾截取出来。
+    """
+
+    left_boundary = r"(?<![A-Za-z0-9\-\u2010\u2011])"
+    return re.search(left_boundary + re.escape(term), text, re.IGNORECASE) is not None
 
 
 def validate_translation(
@@ -134,10 +243,9 @@ def validate_translation(
         errors.append("长正文片段缺少中文译文")
 
     if domain is not None:
-        source_folded = source.casefold()
         target_folded = target.casefold()
         for entry in domain.glossary:
-            if entry.required and entry.source.casefold() in source_folded:
+            if entry.required and source_term_is_present(source, entry.source):
                 if entry.target.casefold() not in target_folded:
                     errors.append(
                         f"领域术语缺失：{entry.source!r} 必须译为包含 {entry.target!r}"

--- a/src/paperlocale/pipeline.py
+++ b/src/paperlocale/pipeline.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from .contracts import read_jsonl, segment_id, validate_translation, write_jsonl_atomic
@@ -176,11 +177,70 @@ def translate_segment_file(
             ordered.extend(accepted)
             write_jsonl_atomic(translations_path, ordered)
         if rejected:
+            # 先保存首轮失败证据。即使随后同 Provider 调用遇到网络错误，
+            # 已通过译文和原始候选仍可从断点复核，不会重复消耗整批额度。
             write_jsonl_atomic(rejected_path, rejected)
-            raise ValueError(
-                f"本批有 {len(rejected)} 条新译文未通过门禁；"
-                f"合格译文已保存，失败候选见 {rejected_path}"
+            rejected_by_id = {str(row["id"]): row for row in rejected}
+            repair_batch = [
+                segment for segment in batch if segment.id in rejected_by_id
+            ]
+            repair_context = replace(
+                context,
+                repair_feedback={
+                    segment.id: (
+                        str(rejected_by_id[segment.id]["target"]),
+                        tuple(str(error) for error in rejected_by_id[segment.id]["errors"]),
+                    )
+                    for segment in repair_batch
+                },
             )
+            repaired = provider.translate(repair_batch, repair_context)
+            if [item.id for item in repaired] != [item.id for item in repair_batch]:
+                raise ValueError("Provider 修复重试返回顺序或 ID 与输入批次不一致")
+
+            repaired_accepted: list[dict[str, object]] = []
+            final_rejected: list[dict[str, object]] = []
+            for source_segment, result in zip(repair_batch, repaired):
+                if source_segment.id in reference_segment_ids:
+                    errors = validate_translation(source_segment.source, result.target, None)
+                else:
+                    errors = validate_translation(source_segment.source, result.target, domain)
+                if errors:
+                    initial = rejected_by_id[source_segment.id]
+                    final_rejected.append(
+                        {
+                            "id": result.id,
+                            "source": source_segment.source,
+                            "target": result.target,
+                            "errors": errors,
+                            "attempts": [
+                                {
+                                    "target": initial["target"],
+                                    "errors": initial["errors"],
+                                },
+                                {"target": result.target, "errors": errors},
+                            ],
+                        }
+                    )
+                    continue
+                repaired_accepted.append(
+                    {
+                        "id": result.id,
+                        "source": source_segment.source,
+                        "target": result.target,
+                    }
+                )
+
+            if repaired_accepted:
+                ordered.extend(repaired_accepted)
+                write_jsonl_atomic(translations_path, ordered)
+            if final_rejected:
+                write_jsonl_atomic(rejected_path, final_rejected)
+                raise ValueError(
+                    f"同一 Provider 定向重试后仍有 {len(final_rejected)} 条译文"
+                    f"未通过门禁；合格译文已保存，失败候选见 {rejected_path}"
+                )
+            rejected_path.unlink()
         if rejected_path.exists():
             # 成功重试后清除已经解决的诊断文件，避免把旧失败误认为当前状态。
             rejected_path.unlink()

--- a/src/paperlocale/providers/base.py
+++ b/src/paperlocale/providers/base.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Mapping
 
+from ..contracts import protected_counts
 from ..domains import DomainPack
 
 
@@ -35,6 +36,11 @@ class TranslationContext:
     domain: DomainPack
     reference_policy: str = "preserve"
     reference_segment_ids: frozenset[str] = frozenset()
+    # 首轮候选未通过内容合同时，流水线只把失败片段、上一版候选和具体错误
+    # 交还同一 Provider。映射为空表示普通首轮翻译，不改变既有调用方。
+    repair_feedback: Mapping[str, tuple[str, tuple[str, ...]]] = field(
+        default_factory=dict
+    )
 
 
 class TranslationProvider(ABC):
@@ -99,8 +105,10 @@ def build_prompt(segments: list[Segment], context: TranslationContext) -> str:
         f"- {entry.source} => {entry.target}"
         for entry in context.domain.glossary
     )
-    payload = [
-        {
+    payload: list[dict[str, object]] = []
+    for segment in segments:
+        counts = protected_counts(segment.source)
+        item: dict[str, object] = {
             "id": segment.id,
             "kind": (
                 "reference"
@@ -108,14 +116,32 @@ def build_prompt(segments: list[Segment], context: TranslationContext) -> str:
                 else "body"
             ),
             "source": segment.source,
+            # 精确列出当前片段必须保留的标记及次数，避免模型把 US、NDVI、
+            # 图号或带连字符变量自然改写后再被门禁稳定拒绝。
+            "must_preserve": {
+                category: dict(values)
+                for category, values in counts.items()
+                if values
+            },
         }
-        for segment in segments
-    ]
+        feedback = context.repair_feedback.get(segment.id)
+        if feedback is not None:
+            previous_target, errors = feedback
+            item["previous_target"] = previous_target
+            item["validation_errors"] = list(errors)
+        payload.append(item)
     reference_instruction = ""
     if context.reference_policy == "translate-titles":
         reference_instruction = """
 5. 对 kind=reference 的条目，只把作品标题译为目标语言；作者、年份、期刊或出版社、
    卷期页码、DOI、URL 和其他书目信息必须保持原样，不套用正文固定术语。
+"""
+    repair_instruction = ""
+    if context.repair_feedback:
+        repair_instruction = """
+6. 本批是合同修复重试。逐条依据 validation_errors 修正 previous_target；
+   must_preserve 中每个表面形式必须至少保留指定次数，不要省略重复图号、
+   变量、单位或引文。仍需返回完整 target，不能只返回差异或解释。
 """
     return f"""{context.domain.prompt}
 
@@ -125,6 +151,7 @@ def build_prompt(segments: list[Segment], context: TranslationContext) -> str:
 3. 保留所有数字、正负号、单位、变量缩写、数据集名、URL、DOI 和引文标记。
 4. 只返回符合约定结构的 JSON，不添加解释、Markdown 或原文之外的信息。
 {reference_instruction}
+{repair_instruction}
 
 固定术语（仅适用于 kind=body）：
 {glossary}

--- a/src/paperlocale/providers/qwen_mt.py
+++ b/src/paperlocale/providers/qwen_mt.py
@@ -10,7 +10,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from ..contracts import FORMULA_RE, STYLE_RE, protected_counts
+from ..contracts import FORMULA_RE, STYLE_RE, protected_counts, source_term_is_present
 from .base import Segment, Translation, TranslationContext, TranslationProvider
 
 
@@ -116,9 +116,8 @@ class QwenMTProvider(TranslationProvider):
             # 官方术语干预同时承担两项职责：固定领域译法，并强制模型原样保留
             # 公式占位符、缩写、单位、URL 与 DOI。重复源词只保留第一条映射。
             terms_by_source: dict[str, str] = {}
-            source_folded = segment.source.casefold()
             for entry in context.domain.glossary:
-                if entry.source.casefold() in source_folded:
+                if source_term_is_present(segment.source, entry.source):
                     terms_by_source.setdefault(entry.source, entry.target)
             counts = protected_counts(segment.source)
             for category in ("url", "doi", "number", "abbreviation", "unit"):

--- a/src/paperlocale/workflow.py
+++ b/src/paperlocale/workflow.py
@@ -55,6 +55,10 @@ STATES = (
     "accepted",
 )
 SCHEMA_VERSION = 4
+UNATTENDED_ACTOR = "paperlocale-unattended"
+UNATTENDED_PASSTHROUGH_REASON = (
+    "PaperLocale 确定性版面安全规则识别为不能独立翻译，无人值守模式原样保留"
+)
 
 
 def _utc_now() -> str:
@@ -333,6 +337,82 @@ def _load_reference_configuration(
     return selected, map_path
 
 
+def _prepare_unattended_configuration(
+    root: Path,
+    manifest: dict[str, object],
+) -> dict[str, object]:
+    """为无人值守运行生成确定性参考文献与片段安全映射。
+
+    无人值守模式只接受现有算法已经给出的确定性结果：不猜测
+    额外参考文献范围，也不把普通合同失败改为透传。生成的映射仍
+    绑定源 PDF 和 ``segments.jsonl`` 哈希，因此断点续跑不会静默换文件。
+    """
+
+    if manifest["status"] != "collected":
+        raise ValueError(
+            f"无人值守准备只接受 collected，当前为 {manifest['status']}"
+        )
+    reference_map_path = root / "reference_map.json"
+    if not reference_map_path.is_file():
+        confirm_reference_run(
+            root,
+            additional_segment_ids=[],
+            excluded_automatic_segment_ids=[],
+            confirmed_by=UNATTENDED_ACTOR,
+        )
+        manifest = load_manifest(root)
+    reference_mapping = load_reference_map(
+        source_sha256=str(manifest["source_sha256"]),
+        segments_path=Path(str(manifest["segments_path"])),
+        map_path=reference_map_path,
+    )
+    reference_ids = {
+        str(segment_id)
+        for segment_id in reference_mapping["reference_segment_ids"]
+    }
+
+    # 先生成现有的确定性安全清单，再只补齐尚未映射的 ID。
+    # 这些片段是被版面引擎拆断的 ASCII 词或页面不可定位的短对象；
+    # 让模型独立改写它们可能比原样保留更容易损坏 PDF 文本对象。
+    summary = prepare_segment_safety_review(
+        source_pdf=Path(str(manifest["source_pdf"])),
+        source_sha256=str(manifest["source_sha256"]),
+        segments_path=Path(str(manifest["segments_path"])),
+        output_dir=root,
+    )
+    required_ids = [
+        str(segment_id)
+        for segment_id in summary["required_passthrough_segment_ids"]
+        if str(segment_id) not in reference_ids
+    ]
+    passthrough_ids: set[str] = set()
+    passthrough_map_path = root / "passthrough_map.json"
+    if passthrough_map_path.is_file():
+        passthrough_ids, _ = _load_passthrough_configuration(root, manifest)
+    missing_ids = [
+        segment_id
+        for segment_id in required_ids
+        if segment_id not in passthrough_ids
+    ]
+    if missing_ids:
+        confirm_passthrough_run(
+            root,
+            segment_ids=missing_ids,
+            reason=UNATTENDED_PASSTHROUGH_REASON,
+            confirmed_by=UNATTENDED_ACTOR,
+        )
+        manifest = load_manifest(root)
+
+    # 清单中明确记录自动模式及其实际采用的边界数量，
+    # 后续不会把系统决定误报为人工复核。
+    manifest["execution_mode"] = "unattended"
+    manifest["unattended_reference_segment_count"] = len(reference_ids)
+    manifest["unattended_passthrough_segment_count"] = len(required_ids)
+    manifest["schema_version"] = SCHEMA_VERSION
+    save_manifest(root, manifest)
+    return manifest
+
+
 def _load_passthrough_configuration(
     root: Path,
     manifest: dict[str, object],
@@ -469,6 +549,54 @@ def _recorded_segment_safety_configuration(
     if missing:
         raise ValueError(f"片段安全复核所需透传映射不闭合：{missing}")
     return required
+
+
+def _provider_resume_identity(provenance: dict[str, object]) -> dict[str, object]:
+    """返回决定断点能否续跑的 Provider 配置身份。
+
+    Codex CLI 会随桌面应用更新，其版本号是可审计的执行环境信息，
+    但不改变用户已锁定的 Provider、模型或推理强度。其他 Provider
+    仍使用完整 provenance 作为断点身份，不扩大兼容边界。
+    """
+
+    identity = dict(provenance)
+    if identity.get("provider") == "codex-local":
+        identity.pop("codex_cli_version", None)
+    return identity
+
+
+def _record_provider_version_transition(
+    manifest: dict[str, object],
+    *,
+    recorded_provider: dict[str, object],
+    current_provider: dict[str, object],
+) -> None:
+    """记录同一 Codex 配置在断点间的 CLI 版本变化。"""
+
+    history_value = manifest.get("translation_provider_history")
+    if history_value is None:
+        history: list[dict[str, object]] = [
+            {
+                "observed_at": str(manifest.get("created_at", "")),
+                "translation_count_before": 0,
+                "provenance": dict(recorded_provider),
+            }
+        ]
+    elif isinstance(history_value, list) and all(
+        isinstance(entry, dict) for entry in history_value
+    ):
+        history = list(history_value)
+    else:
+        raise ValueError("translation_provider_history 字段非法")
+
+    current_entry = {
+        "observed_at": _utc_now(),
+        "translation_count_before": int(manifest.get("translation_count", 0)),
+        "provenance": dict(current_provider),
+    }
+    if not history or history[-1].get("provenance") != current_entry["provenance"]:
+        history.append(current_entry)
+    manifest["translation_provider_history"] = history
 
 
 def _layout_provenance(executable: str) -> dict[str, str]:
@@ -682,6 +810,7 @@ def translate_run(
     max_segments: int = 200,
     max_characters: int = 30000,
     reference_policy: str = "preserve",
+    unattended: bool = False,
 ) -> tuple[int, int]:
     """翻译已收集片段，成功后把运行推进到 ``translated``。"""
 
@@ -691,6 +820,8 @@ def translate_run(
         raise ValueError(f"translate 不接受状态：{manifest['status']}")
     _verify_source_pdf(manifest)
     _verify_domain_languages(manifest, domain)
+    if unattended and manifest["status"] == "collected":
+        manifest = _prepare_unattended_configuration(root, manifest)
     reference_ids, reference_map_path = _load_reference_configuration(
         root,
         manifest,
@@ -714,14 +845,23 @@ def translate_run(
     provider_provenance = provider.provenance()
     recorded_provider = manifest.get("translation_provider")
     if isinstance(recorded_provider, dict) and recorded_provider != provider_provenance:
-        raise ValueError(
-            "Provider 配置与已有断点译文不一致："
-            f"run={recorded_provider!r}, current={provider_provenance!r}"
+        if _provider_resume_identity(recorded_provider) != _provider_resume_identity(
+            provider_provenance
+        ):
+            raise ValueError(
+                "Provider 配置与已有断点译文不一致："
+                f"run={recorded_provider!r}, current={provider_provenance!r}"
+            )
+        _record_provider_version_transition(
+            manifest,
+            recorded_provider=recorded_provider,
+            current_provider=provider_provenance,
         )
     # 在模型调用前绑定领域包和 Provider；即使本批只有部分译文通过，
     # 已原子保存的断点也不会变成来源不明的数据。
     manifest["domain_pack"] = _domain_provenance(domain)
-    manifest["translation_provider"] = provider_provenance
+    if not isinstance(recorded_provider, dict):
+        manifest["translation_provider"] = provider_provenance
     manifest["reference_policy"] = reference_policy
     manifest["reference_map"] = str(reference_map_path.resolve())
     manifest["reference_map_sha256"] = _sha256(reference_map_path)
@@ -923,6 +1063,257 @@ def _verify_vector_repair(before: Path, candidate: Path) -> list[dict[str, int]]
     return changes
 
 
+def _vector_drawing_key(drawing: dict[str, object]) -> tuple[float, ...]:
+    """使用与机器 QA 一致的 0.01 PDF 点边界生成矢量对象身份。"""
+
+    return tuple(round(float(value), 2) for value in drawing["rect"])
+
+
+def _missing_source_vector_drawings(
+    source_page: fitz.Page,
+    translated_page: fitz.Page,
+) -> list[dict[str, object]]:
+    """按边界和重复次数返回译文页中缺失的源矢量绘图。"""
+
+    translated_counts: dict[tuple[float, ...], int] = {}
+    for drawing in translated_page.get_drawings():
+        key = _vector_drawing_key(drawing)
+        translated_counts[key] = translated_counts.get(key, 0) + 1
+
+    missing: list[dict[str, object]] = []
+    for drawing in source_page.get_drawings():
+        key = _vector_drawing_key(drawing)
+        if translated_counts.get(key, 0):
+            translated_counts[key] -= 1
+        else:
+            missing.append(drawing)
+    return missing
+
+
+def _replay_vector_drawing(
+    page: fitz.Page,
+    drawing: dict[str, object],
+) -> None:
+    """用 PyMuPDF 原生路径操作重放一个源矢量对象。"""
+
+    shape = page.new_shape()
+    for item in drawing["items"]:
+        operator = item[0]
+        if operator == "l":
+            shape.draw_line(item[1], item[2])
+        elif operator == "c":
+            shape.draw_bezier(item[1], item[2], item[3], item[4])
+        elif operator == "re":
+            shape.draw_rect(item[1])
+        elif operator == "qu":
+            shape.draw_quad(item[1])
+        else:
+            raise ValueError(f"源 PDF 包含不支持的矢量操作：{operator!r}")
+
+    line_cap_value = drawing.get("lineCap")
+    if isinstance(line_cap_value, (tuple, list)):
+        line_cap = max(int(value) for value in line_cap_value)
+    elif line_cap_value is None:
+        line_cap = 0
+    else:
+        line_cap = int(line_cap_value)
+    line_join_value = drawing.get("lineJoin")
+    width_value = drawing.get("width")
+    shape.finish(
+        width=float(width_value) if width_value is not None else 1.0,
+        color=drawing.get("color"),
+        fill=drawing.get("fill"),
+        lineCap=line_cap,
+        lineJoin=int(line_join_value) if line_join_value is not None else 0,
+        dashes=drawing.get("dashes"),
+        even_odd=bool(drawing.get("even_odd", False)),
+        closePath=bool(drawing.get("closePath", False)),
+        fill_opacity=float(drawing.get("fill_opacity") or 1.0),
+        stroke_opacity=float(drawing.get("stroke_opacity") or 1.0),
+    )
+    shape.commit(overlay=True)
+
+
+def restore_source_vectors(
+    run_dir: Path,
+    *,
+    description: str,
+) -> Path:
+    """只重放译文 PDF 中按精确边界缺失的源矢量路径。
+
+    候选先写入独立临时 PDF，再复用 ``apply_vector_repair`` 的文字、
+    页面、图片和矢量增量验证与原子替换，不直接改写已绑定产物。
+    """
+
+    if not description.strip():
+        raise ValueError("description 不能为空")
+    root = run_dir.expanduser().resolve()
+    manifest = load_manifest(root)
+    if manifest["status"] not in {"rendered", "qa_generated", "accepted"}:
+        raise ValueError(
+            "restore-source-vectors 只接受 rendered、qa_generated 或 accepted，"
+            f"当前为 {manifest['status']}"
+        )
+    source = _verify_source_pdf(manifest)
+    rendered = _verify_rendered_pdf(manifest)
+    qa_report_path = root / "qa" / "qa_report.json"
+    if not qa_report_path.is_file():
+        raise FileNotFoundError("缺少机器 QA 报告；请先执行 paperlocale qa")
+    qa_report = json.loads(qa_report_path.read_text(encoding="utf-8"))
+    # 矢量恢复只能消费与当前源文件、当前译文候选同时绑定的 QA 结论。
+    # 仅凭路径或旧报告中的页号不足以证明它仍属于这一次 PDF 状态。
+    if qa_report.get("source_sha256") != manifest["source_sha256"]:
+        raise ValueError("机器 QA 报告不属于当前源 PDF")
+    if qa_report.get("translated_sha256") != manifest["rendered_sha256"]:
+        raise ValueError("机器 QA 报告不属于当前译文 PDF")
+    qa_pages = qa_report.get("pages")
+    if not isinstance(qa_pages, list):
+        raise ValueError("机器 QA 报告缺少 pages")
+    # QA 中 source > translated 的页集合是本次修复的唯一允许列表；即使逐对象
+    # 比较在其他页面发现细小边界差异，也不得越过机器 QA 的页级门禁进行重放。
+    vector_loss_pages = {
+        int(page["page"])
+        for page in qa_pages
+        if isinstance(page, dict)
+        and isinstance(page.get("page"), int)
+        and isinstance(page.get("source_vector_drawings"), int)
+        and isinstance(page.get("translated_vector_drawings"), int)
+        and page["source_vector_drawings"] > page["translated_vector_drawings"]
+    }
+    if not vector_loss_pages:
+        raise ValueError("机器 QA 没有报告矢量绘图减少页")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    candidate = root / f".source-vector-repair-{timestamp}.pdf"
+    source_document = fitz.open(source)
+    translated_document = fitz.open(rendered)
+    restored_pages: list[dict[str, object]] = []
+    try:
+        if source_document.page_count != translated_document.page_count:
+            raise ValueError("源 PDF 与译文 PDF 页数不一致")
+        for page_index in range(source_document.page_count):
+            if page_index + 1 not in vector_loss_pages:
+                continue
+            source_page = source_document[page_index]
+            translated_page = translated_document[page_index]
+            missing = _missing_source_vector_drawings(source_page, translated_page)
+            if not missing:
+                continue
+            for drawing in missing:
+                _replay_vector_drawing(translated_page, drawing)
+            restored_pages.append(
+                {
+                    "page": page_index + 1,
+                    "restored_count": len(missing),
+                    "bboxes": [
+                        [round(float(value), 3) for value in drawing["rect"]]
+                        for drawing in missing
+                    ],
+                }
+            )
+        if not restored_pages:
+            raise ValueError("译文 PDF 没有按精确边界缺失的源矢量对象")
+        translated_document.save(candidate, garbage=4, deflate=True)
+    finally:
+        translated_document.close()
+        source_document.close()
+
+    try:
+        repaired = apply_vector_repair(
+            root,
+            repaired_pdf=candidate,
+            description=description,
+        )
+        repaired_manifest = load_manifest(root)
+        history = repaired_manifest.get("repair_history")
+        if not isinstance(history, list) or not history:
+            raise RuntimeError("源矢量修复后缺少 repair_history")
+        last_entry = history[-1]
+        if not isinstance(last_entry, dict):
+            raise RuntimeError("repair_history 最后一项格式非法")
+        last_entry["source_vector_restoration"] = restored_pages
+        save_manifest(root, repaired_manifest)
+        return repaired
+    finally:
+        candidate.unlink(missing_ok=True)
+
+
+def rollback_last_repair(
+    run_dir: Path,
+    *,
+    reason: str,
+) -> Path:
+    """按 repair_history 哈希绑定备份回滚最后一次 PDF 修复。"""
+
+    if not reason.strip():
+        raise ValueError("reason 不能为空")
+    root = run_dir.expanduser().resolve()
+    manifest = load_manifest(root)
+    if manifest["status"] not in {"rendered", "qa_generated", "accepted"}:
+        raise ValueError(
+            "rollback-last-repair 只接受 rendered、qa_generated 或 accepted，"
+            f"当前为 {manifest['status']}"
+        )
+    _verify_source_pdf(manifest)
+    rendered = _verify_rendered_pdf(manifest)
+    history = manifest.get("repair_history")
+    if not isinstance(history, list) or not history:
+        raise ValueError("当前运行没有可回滚的 repair_history")
+    # repair_history 是按 before -> after 串联的修复链。回滚只能从链尾开始，
+    # 否则会跳过后续修复，使当前 PDF 与审计历史失去一一对应关系。
+    last_entry = history[-1]
+    if not isinstance(last_entry, dict):
+        raise ValueError("repair_history 最后一项格式非法")
+    before_hash = last_entry.get("before_sha256")
+    after_hash = last_entry.get("after_sha256")
+    backup_value = last_entry.get("backup_pdf")
+    if not all(
+        isinstance(value, str) and value
+        for value in (before_hash, after_hash, backup_value)
+    ):
+        raise ValueError("repair_history 最后一项缺少回滚身份")
+    if manifest["rendered_sha256"] != after_hash:
+        raise ValueError("当前译文 PDF 已不是最后一次修复的产物")
+    backup = Path(backup_value).expanduser().resolve()
+    if not backup.is_file() or _sha256(backup) != before_hash:
+        raise ValueError("最后一次修复的备份不存在或哈希不一致")
+
+    current_snapshot = root / f".rollback-current-{after_hash[:12]}.pdf"
+    shutil.copy2(rendered, current_snapshot)
+    temporary = rendered.with_name(rendered.name + ".rollback.tmp")
+    try:
+        # 备份先复制到目标 PDF 同目录，再用原子替换恢复；复制、替换、清单更新
+        # 共用同一恢复边界，任一步失败都把 PDF 还原为调用前的 after 版本。
+        shutil.copy2(backup, temporary)
+        temporary.replace(rendered)
+        if _sha256(rendered) != before_hash:
+            raise RuntimeError("回滚后 PDF 哈希与备份不一致")
+        rolled_back = dict(last_entry)
+        rolled_back["rolled_back_at"] = _utc_now()
+        rolled_back["rollback_reason"] = reason.strip()
+        rollback_history = manifest.setdefault("repair_rollback_history", [])
+        if not isinstance(rollback_history, list):
+            raise ValueError("repair_rollback_history 字段非法")
+        rollback_history.append(rolled_back)
+        history.pop()
+        manifest["rendered_sha256"] = before_hash
+        manifest["status"] = "rendered"
+        manifest["schema_version"] = SCHEMA_VERSION
+        # QA 与人工 accept 都绑定回滚前的 after 哈希，因此只解除清单中的当前
+        # 绑定；历史 QA 文件和逐页对照图仍保留在磁盘，供后续审计而不冒充现状。
+        manifest.pop("qa_report", None)
+        manifest.pop("accepted_by", None)
+        save_manifest(root, manifest)
+        return rendered
+    except Exception:
+        restore = rendered.with_name(rendered.name + ".rollback-restore.tmp")
+        shutil.copy2(current_snapshot, restore)
+        restore.replace(rendered)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+        current_snapshot.unlink(missing_ok=True)
+
+
 def apply_vector_repair(
     run_dir: Path,
     *,
@@ -1105,6 +1496,7 @@ def _create_text_repair_candidate(
     replacement: str,
     font_file: Path | None,
     font_size: float | None,
+    single_line: bool,
 ) -> dict[str, object]:
     """只在候选中删除指定文字，并在需要时嵌入子集替换字体。"""
 
@@ -1135,9 +1527,12 @@ def _create_text_repair_candidate(
         if list(page.annots(types=(fitz.PDF_ANNOT_REDACT,)) or []):
             raise ValueError(f"第{page_number}页已有 redaction 标注，拒绝批量应用")
 
+        placement_evidence: dict[str, object]
         if replacement:
             if font_file is None or font_size is None:
                 raise ValueError("非空 replacement 必须提供 font-file 和 font-size")
+            if single_line and ("\n" in replacement or "\r" in replacement):
+                raise ValueError("single-line replacement 不能包含换行")
             subset_bytes, font_evidence = _subset_repair_font(font_file, replacement)
             font_resource_name = str(font_evidence["font_resource_name"])
         else:
@@ -1155,6 +1550,7 @@ def _create_text_repair_candidate(
                 "font_program_bytes_after_subset": 0,
                 "font_subset_bytes_saved": 0,
             }
+            placement_evidence = {"placement_mode": "removal-only"}
         # redaction 只负责移除文字；透明填充避免白色覆盖层遮住矩形内仍保留的
         # 图片或矢量对象。下面的 images/graphics NONE 则禁止删除这些对象本身。
         page.add_redact_annot(rectangle, fill=False, cross_out=False)
@@ -1171,17 +1567,48 @@ def _create_text_repair_candidate(
                 fontname=font_resource_name,
                 fontbuffer=subset_bytes,
             )
-            remaining_height = page.insert_textbox(
-                rectangle,
-                replacement,
-                fontname=font_resource_name,
-                fontsize=font_size,
-                color=(0, 0, 0),
-            )
-            if remaining_height < 0:
-                raise ValueError(
-                    "replacement 无法放入 rect；请扩大矩形或减小 --font-size"
+            if single_line:
+                repair_font = fitz.Font(fontbuffer=subset_bytes)
+                text_width = repair_font.text_length(replacement, fontsize=font_size)
+                text_height = font_size * (
+                    repair_font.ascender - repair_font.descender
                 )
+                if text_width > rectangle.width or text_height > rectangle.height:
+                    raise ValueError(
+                        "single-line replacement 无法放入 rect："
+                        f"text=({text_width:.3f}, {text_height:.3f}), "
+                        f"rect=({rectangle.width:.3f}, {rectangle.height:.3f})"
+                    )
+                baseline = rectangle.y0 + font_size * repair_font.ascender
+                page.insert_text(
+                    fitz.Point(rectangle.x0, baseline),
+                    replacement,
+                    fontname=font_resource_name,
+                    fontsize=font_size,
+                    color=(0, 0, 0),
+                )
+                placement_evidence = {
+                    "placement_mode": "single-line",
+                    "text_width": round(float(text_width), 3),
+                    "text_height": round(float(text_height), 3),
+                    "baseline": round(float(baseline), 3),
+                }
+            else:
+                remaining_height = page.insert_textbox(
+                    rectangle,
+                    replacement,
+                    fontname=font_resource_name,
+                    fontsize=font_size,
+                    color=(0, 0, 0),
+                )
+                if remaining_height < 0:
+                    raise ValueError(
+                        "replacement 无法放入 rect；请扩大矩形或减小 --font-size"
+                    )
+                placement_evidence = {
+                    "placement_mode": "textbox",
+                    "remaining_height": round(float(remaining_height), 3),
+                }
 
             embedded_font = document.extract_font(font_xref)[-1]
             if hashlib.sha256(embedded_font).hexdigest() != font_evidence[
@@ -1194,6 +1621,7 @@ def _create_text_repair_candidate(
 
     return {
         "before_text": before_text,
+        **placement_evidence,
         **font_evidence,
     }
 
@@ -1273,10 +1701,13 @@ def apply_text_repair(
     font_file: Path | None,
     font_size: float | None,
     description: str,
+    single_line: bool = False,
 ) -> Path:
     """在一个明确矩形内受控替换文字，并强制重新执行机器与人工 QA。"""
 
     removal_only = replacement == ""
+    if removal_only and single_line:
+        raise ValueError("single-line 只适用于非空 replacement")
     if not removal_only and not replacement.strip():
         raise ValueError("replacement 不能只包含空白字符")
     if not description.strip():
@@ -1313,6 +1744,7 @@ def apply_text_repair(
             replacement=replacement,
             font_file=resolved_font,
             font_size=font_size,
+            single_line=single_line,
         )
         structure = _verify_text_repair(
             before=rendered,
@@ -1383,6 +1815,7 @@ def run_to_qa(
     reference_policy: str = "preserve",
     max_segments: int = 200,
     max_characters: int = 30000,
+    unattended: bool = False,
 ) -> dict[str, object]:
     """从当前断点沿唯一生产路径推进到机器 QA，保留人工验收边界。
 
@@ -1406,6 +1839,7 @@ def run_to_qa(
             max_segments=max_segments,
             max_characters=max_characters,
             reference_policy=reference_policy,
+            unattended=unattended,
         )
         manifest = load_manifest(root)
     if manifest["status"] == "translated":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ from paperlocale.cli import _initialize_or_load_run, _provider_from_args, build_
 
 
 class CliTest(unittest.TestCase):
-    def test_package_version_matches_v041_candidate_line(self) -> None:
-        self.assertEqual(__version__, "0.4.1")
+    def test_package_version_matches_v042_release_line(self) -> None:
+        self.assertEqual(__version__, "0.4.2")
 
     def test_cli_reports_package_version(self) -> None:
         """发布包必须能直接报告可核对的版本。"""
@@ -39,6 +39,7 @@ class CliTest(unittest.TestCase):
                 "high",
                 "--domain",
                 "atmospheric-science",
+                "--unattended",
             ]
         )
         self.assertEqual(args.command, "run")
@@ -46,6 +47,7 @@ class CliTest(unittest.TestCase):
         self.assertEqual(args.domain, "atmospheric-science")
         self.assertEqual(args.reasoning_effort, "high")
         self.assertEqual(args.reference_policy, "preserve")
+        self.assertTrue(args.unattended)
 
     def test_confirm_references_accepts_repeated_manual_ids(self) -> None:
         """人工复核命令应把多个乱序参考文献片段明确传给工作流。"""
@@ -123,6 +125,7 @@ class CliTest(unittest.TestCase):
                 "NotoSansCJKsc-Regular.otf",
                 "--font-size",
                 "9.5",
+                "--single-line",
                 "--description",
                 "修复跨对象碎裂图注",
             ]
@@ -131,6 +134,54 @@ class CliTest(unittest.TestCase):
         self.assertEqual(args.page, 27)
         self.assertEqual(args.rect, [40.0, 120.0, 500.0, 160.0])
         self.assertEqual(args.font_size, 9.5)
+        self.assertTrue(args.single_line)
+
+    def test_restore_source_vectors_requires_run_and_description(self) -> None:
+        """源矢量重放必须通过显式、可审计的 PaperLocale 命令执行。"""
+
+        args = build_parser().parse_args(
+            [
+                "restore-source-vectors",
+                "--run-dir",
+                "run",
+                "--description",
+                "restore machine-QA missing source vectors",
+            ]
+        )
+        self.assertEqual(args.command, "restore-source-vectors")
+        self.assertEqual(args.run_dir, Path("run"))
+
+    def test_rollback_last_repair_passes_reason_and_reports_result(self) -> None:
+        """CLI 必须把显式回滚原因传给工作流，并打印恢复后的 PDF 路径。"""
+
+        restored = Path("/tmp/restored.pdf")
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "paperlocale",
+                    "rollback-last-repair",
+                    "--run-dir",
+                    "run",
+                    "--reason",
+                    "remove audited repair",
+                ],
+            ),
+            patch(
+                "paperlocale.cli.rollback_last_repair",
+                return_value=restored,
+            ) as rollback,
+            patch("builtins.print") as output,
+        ):
+            self.assertEqual(cli.main(), 0)
+
+        rollback.assert_called_once_with(
+            Path("run"),
+            reason="remove audited repair",
+        )
+        output.assert_called_once_with(
+            f"最后一次修复已回滚并记录：{restored}；请重新执行 qa"
+        )
 
     def test_codex_provider_requires_explicit_model_for_auditing(self) -> None:
         """忽略用户配置后不能把未知默认模型写成可审计运行。"""
@@ -201,6 +252,7 @@ class CliTest(unittest.TestCase):
             qa_generated = {
                 "status": "qa_generated",
                 "qa_output_dir": str(run_dir / "qa"),
+                "rendered_pdf": str(run_dir / "render_output" / "translated.pdf"),
             }
             with (
                 patch(
@@ -228,6 +280,7 @@ class CliTest(unittest.TestCase):
                 self.assertEqual(cli.main(), 0)
             build_provider.assert_not_called()
             self.assertIsNone(run.call_args.kwargs["provider"])
+            self.assertFalse(run.call_args.kwargs["unattended"])
 
 
 if __name__ == "__main__":

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from paperlocale.contracts import (
     protected_counts,
     segment_id,
+    source_term_is_present,
     validate_translation,
     validate_translation_files,
     write_jsonl_atomic,
@@ -52,9 +53,89 @@ class TranslationContractTest(unittest.TestCase):
     def test_section_headings_are_not_treated_as_abbreviations(self) -> None:
         """论文结构标题不是必须原样保留的科学缩写。"""
 
-        for heading in ("ABSTRACT", "KEYWORDS", "REFERENCES"):
+        headings = (
+            "ABSTRACT",
+            "SUPPLEMENTARY MATERIALS",
+            "FIGURE S1",
+            "DATA AVAILABILITY STATEMENT",
+            "RESULTS AND DISCUSSION",
+            "COPULA-BASED SPATIO-TEMPORAL PATTERNS OF PRECIPITATION EXTREMES",
+        )
+        for heading in headings:
             with self.subTest(heading=heading):
-                self.assertEqual(protected_counts(heading)["abbreviation"], {})
+                remaining = protected_counts(heading)["abbreviation"]
+                # 图号 S1 是需要保留的真实标记；其余全大写普通栏目词可翻译。
+                self.assertEqual(remaining, {"S1": 1} if heading == "FIGURE S1" else {})
+
+    def test_geographic_abbreviations_may_be_naturally_translated(self) -> None:
+        """国家名和明确的美国地址州码可译为中文，不要求重复英文表面形式。"""
+
+        source = "Offices in the US, UK, and Denver, CO, USA were contacted."
+        target = "研究联系了美国、英国以及美国科罗拉多州丹佛的办事处。"
+        self.assertEqual(validate_translation(source, target), [])
+
+    def test_scientific_co_and_dh_remain_protected(self) -> None:
+        """地理地址例外不能放宽真实科学缩写。"""
+
+        counts = protected_counts("CO concentration and DH events")
+        self.assertEqual(counts["abbreviation"], {"CO": 1, "DH": 1})
+
+    def test_stylized_journal_name_does_not_create_abbreviation(self) -> None:
+        """艺术字大小写不能在普通单词内部制造虚假的缩写。"""
+
+        self.assertEqual(
+            protected_counts("SciEnTific REpoRTS")['abbreviation'],
+            {},
+        )
+
+    def test_glossary_term_requires_left_word_boundary(self) -> None:
+        """temporal 不能从 spatiotemporal 或 spatio-temporal 尾部误命中。"""
+
+        self.assertFalse(
+            source_term_is_present("high spatiotemporal resolution", "temporal resolution")
+        )
+        self.assertFalse(
+            source_term_is_present("high spatio-temporal resolution", "temporal resolution")
+        )
+        self.assertEqual(
+            validate_translation(
+                "The data have high spatiotemporal resolution.",
+                "该资料具有高时空分辨率。",
+                self.domain,
+            ),
+            [],
+        )
+
+    def test_glossary_singular_still_matches_plural(self) -> None:
+        """术语表单数词形继续约束原文中的复数形式。"""
+
+        self.assertTrue(
+            source_term_is_present("compound hot-dry events", "compound hot-dry event")
+        )
+        self.assertTrue(
+            any(
+                "领域术语" in error
+                for error in validate_translation(
+                    "Compound hot-dry events increased.",
+                    "这些复合事件有所增加。",
+                    self.domain,
+                )
+            )
+        )
+
+    def test_initials_and_accented_words_are_not_units(self) -> None:
+        """姓名首字母和重音词内部的大写 M 不是米制单位。"""
+
+        text = "M. Reichstein; Centre National de Recherches Météorologiques"
+        self.assertEqual(protected_counts(text)["unit"], {})
+
+    def test_scientific_units_remain_protected(self) -> None:
+        """收窄误报后，常见科学单位仍按大小写精确保护。"""
+
+        self.assertEqual(
+            protected_counts("10 m, 5 mm, 300 K, 20 Pa, and 5 hPa")["unit"],
+            {"m": 1, "mm": 1, "K": 1, "Pa": 1, "hPa": 1},
+        )
 
     def test_hyphenated_decade_keeps_year_without_false_negative_sign(self) -> None:
         """mid-1960s 应保护年代 1960，但连字符不是负号。"""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,6 +51,25 @@ class _SingleSegmentProvider(_MappingProvider):
         return super().translate(segments, context)
 
 
+class _RepairingProvider(TranslationProvider):
+    """首轮返回坏候选，收到同一 Provider 修复反馈后返回合格译文。"""
+
+    def __init__(self, source: str, initial: str, repaired: str) -> None:
+        self.source = source
+        self.initial = initial
+        self.repaired = repaired
+        self.contexts: list[TranslationContext] = []
+
+    def translate(
+        self,
+        segments: list[Segment],
+        context: TranslationContext,
+    ) -> list[Translation]:
+        self.contexts.append(context)
+        target = self.repaired if context.repair_feedback else self.initial
+        return [Translation(segment.id, target) for segment in segments]
+
+
 class PipelineTest(unittest.TestCase):
     def test_batches_respect_character_limit(self) -> None:
         segments = [Segment(str(index), "x" * 10) for index in range(5)]
@@ -170,6 +189,61 @@ class PipelineTest(unittest.TestCase):
             self.assertEqual(len(read_jsonl(translations)), 3)
             self.assertFalse(rejected_path.exists())
 
+    def test_contract_failure_is_repaired_by_the_same_provider(self) -> None:
+        """失败片段携带候选和错误定向重试，不重译同批已合格片段。"""
+
+        source = "The NDVI value was 2.0."
+        provider = _RepairingProvider(
+            source,
+            initial="该值为2.0。",
+            repaired="NDVI值为2.0。",
+        )
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            segments = root / "segments.jsonl"
+            translations = root / "translations.jsonl"
+            write_jsonl_atomic(segments, [{"id": segment_id(source), "source": source}])
+
+            self.assertEqual(
+                translate_segment_file(
+                    segments_path=segments,
+                    translations_path=translations,
+                    provider=provider,
+                    domain=domain,
+                ),
+                (0, 1),
+            )
+            self.assertEqual(len(provider.contexts), 2)
+            feedback = provider.contexts[1].repair_feedback[segment_id(source)]
+            self.assertEqual(feedback[0], "该值为2.0。")
+            self.assertTrue(any("NDVI" in error for error in feedback[1]))
+            self.assertEqual(read_jsonl(translations)[0]["target"], "NDVI值为2.0。")
+            self.assertFalse((root / "rejected_translations.jsonl").exists())
+
+    def test_second_contract_failure_keeps_both_attempts(self) -> None:
+        """一次定向重试仍失败时停止，并把两轮候选留作审计证据。"""
+
+        source = "The NDVI value was 2.0."
+        provider = _RepairingProvider(source, initial="该值为2.0。", repaired="数值为2.0。")
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            segments = root / "segments.jsonl"
+            translations = root / "translations.jsonl"
+            write_jsonl_atomic(segments, [{"id": segment_id(source), "source": source}])
+
+            with self.assertRaisesRegex(ValueError, "定向重试后仍有"):
+                translate_segment_file(
+                    segments_path=segments,
+                    translations_path=translations,
+                    provider=provider,
+                    domain=domain,
+                )
+            rejected = read_jsonl(root / "rejected_translations.jsonl")
+            self.assertEqual(len(rejected[0]["attempts"]), 2)
+            self.assertEqual(len(provider.contexts), 2)
+
     def test_preserve_policy_skips_provider_and_body_glossary_for_references(self) -> None:
         """参考文献原样写入，正文仍走模型和领域术语门禁。"""
 
@@ -285,7 +359,9 @@ class PipelineTest(unittest.TestCase):
                 ),
                 (0, 1),
             )
-            self.assertEqual(provider.calls, 1)
+            # 0.4.2 先用同一 Provider 做一次定向合同修复；两次候选
+            # 均失败后才等待透传确认，不再反复调用模型。
+            self.assertEqual(provider.calls, 2)
             self.assertFalse(rejected.exists())
             self.assertEqual(read_jsonl(translations)[0]["target"], source)
             validate_translation_files(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -54,6 +54,8 @@ class ProviderTest(unittest.TestCase):
             self.assertIn("model_reasoning_effort=\"high\"", command)
             self.assertNotIn("auth.json", " ".join(command))
             self.assertIn("待翻译 JSON", str(kwargs["input"]))
+            self.assertIn('"must_preserve"', str(kwargs["input"]))
+            self.assertIn('"mm": 1', str(kwargs["input"]))
             return type("Completed", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
         provider = CodexLocalProvider(
@@ -172,6 +174,31 @@ class ProviderTest(unittest.TestCase):
         ):
             result = provider.translate([self.segment], self.context)
         self.assertEqual(result, [type(result[0])("id-1", "土壤湿度为10 mm。")])
+
+    def test_qwen_mt_does_not_send_substring_glossary_term(self) -> None:
+        """spatiotemporal 不能让 Qwen 收到并不存在的 temporal 术语干预。"""
+
+        segment = Segment("id-spatiotemporal", "High spatiotemporal resolution data.")
+
+        def fake_urlopen(request, timeout: int):
+            body = json.loads(request.data.decode("utf-8"))
+            sources = {entry["source"] for entry in body["translation_options"]["terms"]}
+            self.assertNotIn("temporal resolution", sources)
+            return _Response(
+                {"choices": [{"message": {"content": "高时空分辨率资料。"}}]}
+            )
+
+        provider = QwenMTProvider(
+            base_url="https://example.test/compatible-mode/v1",
+            api_key="secret-key",
+            model="qwen-mt-plus",
+        )
+        with patch(
+            "paperlocale.providers.qwen_mt.urllib.request.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            result = provider.translate([segment], self.context)
+        self.assertEqual(result[0].target, "高时空分辨率资料。")
 
     def test_qwen_mt_restores_formula_placeholders(self) -> None:
         """模型只看到稳定哨兵，Provider 必须在返回前恢复原公式占位符。"""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -38,6 +38,8 @@ from paperlocale.workflow import (
     load_manifest,
     qa_run,
     render_run,
+    restore_source_vectors,
+    rollback_last_repair,
     run_to_qa,
     save_manifest,
     translate_run,
@@ -86,6 +88,31 @@ class _SafetyProvider(TranslationProvider):
         return [Translation(segment.id, "土壤湿度为10 mm。") for segment in segments]
 
 
+class _ProvenanceProvider(TranslationProvider):
+    """使用显式 provenance 和映射译文模拟 Codex 断点续跑。"""
+
+    def __init__(
+        self,
+        provenance: dict[str, object],
+        translations: dict[str, str],
+    ) -> None:
+        self._provenance = provenance
+        self._translations = translations
+
+    def provenance(self) -> dict[str, object]:
+        return dict(self._provenance)
+
+    def translate(
+        self,
+        segments: list[Segment],
+        context: TranslationContext,
+    ) -> list[Translation]:
+        return [
+            Translation(segment.id, self._translations[segment.source])
+            for segment in segments
+        ]
+
+
 class WorkflowTest(unittest.TestCase):
     layout_provenance = {
         "executable": "/fake/pdf2zh_next",
@@ -107,7 +134,7 @@ class WorkflowTest(unittest.TestCase):
             source_language="en",
             target_language="zh-CN",
         )
-        self.assertEqual(manifest["paperlocale_version"], "0.4.1")
+        self.assertEqual(manifest["paperlocale_version"], "0.4.2")
         translated_hash = hashlib.sha256(translated.read_bytes()).hexdigest()
         report_path = run_dir / "qa" / "qa_report.json"
         report_path.parent.mkdir(parents=True)
@@ -129,6 +156,151 @@ class WorkflowTest(unittest.TestCase):
         manifest["qa_report"] = str(report_path)
         save_manifest(run_dir, manifest)
         return run_dir, translated
+
+    def _make_source_vector_repair_run(
+        self,
+        root: Path,
+    ) -> tuple[Path, Path, Path]:
+        """建立两页矢量差异及与当前候选哈希绑定的 QA 夹具。
+
+        两页源 PDF 都比译文多一条线，但 QA 只允许第 1 页恢复。这样既能验证
+        真正的路径重放，也能防止实现绕过 QA 页集合去扫描并修改第 2 页。
+        """
+
+        source = root / "source.pdf"
+        translated = root / "translated.pdf"
+        source_document = fitz.open()
+        translated_document = fitz.open()
+        try:
+            for page_number in (1, 2):
+                source_page = source_document.new_page()
+                translated_page = translated_document.new_page()
+                text = f"stable text page {page_number}"
+                source_page.insert_text((50, 50), text)
+                translated_page.insert_text((50, 50), text)
+                source_page.draw_rect(
+                    fitz.Rect(50, 80, 100, 100),
+                    color=(0, 0, 0),
+                )
+                translated_page.draw_rect(
+                    fitz.Rect(50, 80, 100, 100),
+                    color=(0, 0, 0),
+                )
+                source_page.draw_line(
+                    (50, 120),
+                    (150, 120),
+                    color=(1, 0, 0),
+                )
+            source_document.save(source)
+            translated_document.save(translated)
+        finally:
+            translated_document.close()
+            source_document.close()
+
+        run_dir = root / "run"
+        manifest = initialize_run(
+            source_pdf=source,
+            run_dir=run_dir,
+            source_language="en",
+            target_language="zh-CN",
+        )
+        translated_hash = hashlib.sha256(translated.read_bytes()).hexdigest()
+        report_path = run_dir / "qa" / "qa_report.json"
+        report_path.parent.mkdir(parents=True)
+        report_path.write_text(
+            json.dumps(
+                {
+                    "source_sha256": manifest["source_sha256"],
+                    "translated_sha256": translated_hash,
+                    "pages": [
+                        {
+                            "page": 1,
+                            "source_vector_drawings": 2,
+                            "translated_vector_drawings": 1,
+                        },
+                        {
+                            "page": 2,
+                            "source_vector_drawings": 1,
+                            "translated_vector_drawings": 1,
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest["status"] = "qa_generated"
+        manifest["rendered_pdf"] = str(translated.resolve())
+        manifest["rendered_sha256"] = translated_hash
+        manifest["qa_report"] = str(report_path.resolve())
+        save_manifest(run_dir, manifest)
+        return run_dir, translated, report_path
+
+    def _make_repair_chain_run(
+        self,
+        root: Path,
+    ) -> tuple[Path, Path, Path, Path]:
+        """建立 before0 -> after1 -> after2 的两项可逆修复链。"""
+
+        source = root / "source.pdf"
+        source.write_bytes(b"source-pdf")
+        rendered = root / "rendered.pdf"
+        before_first = b"rendered-before-first-repair"
+        after_first = b"rendered-after-first-repair"
+        after_second = b"rendered-after-second-repair"
+        rendered.write_bytes(after_second)
+
+        run_dir = root / "run"
+        manifest = initialize_run(
+            source_pdf=source,
+            run_dir=run_dir,
+            source_language="en",
+            target_language="zh-CN",
+        )
+        backup_dir = run_dir / "repair_backups"
+        backup_dir.mkdir()
+        first_backup = backup_dir / "before-first.pdf"
+        second_backup = backup_dir / "before-second.pdf"
+        first_backup.write_bytes(before_first)
+        second_backup.write_bytes(after_first)
+
+        before_first_hash = hashlib.sha256(before_first).hexdigest()
+        after_first_hash = hashlib.sha256(after_first).hexdigest()
+        after_second_hash = hashlib.sha256(after_second).hexdigest()
+        manifest["repair_history"] = [
+            {
+                "type": "vector",
+                "description": "first repair",
+                "backup_pdf": str(first_backup.resolve()),
+                "before_sha256": before_first_hash,
+                "after_sha256": after_first_hash,
+            },
+            {
+                "type": "text-overlay",
+                "description": "second repair",
+                "backup_pdf": str(second_backup.resolve()),
+                "before_sha256": after_first_hash,
+                "after_sha256": after_second_hash,
+            },
+        ]
+        qa_report = run_dir / "qa" / "qa_report.json"
+        qa_report.parent.mkdir(parents=True)
+        qa_report.write_text(
+            json.dumps(
+                {
+                    "translated_sha256": after_second_hash,
+                    "visual_accepted": True,
+                    "visual_reviewed_by": "reviewer",
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest["status"] = "accepted"
+        manifest["rendered_pdf"] = str(rendered.resolve())
+        manifest["rendered_sha256"] = after_second_hash
+        manifest["qa_report"] = str(qa_report.resolve())
+        manifest["accepted_by"] = "reviewer"
+        save_manifest(run_dir, manifest)
+        return run_dir, rendered, second_backup, qa_report
 
     def _make_text_repair_run(
         self, root: Path
@@ -281,7 +453,7 @@ class WorkflowTest(unittest.TestCase):
             )
 
     def test_run_to_qa_advances_initialized_run_without_accepting(self) -> None:
-        """一键运行复用全部阶段，但必须停在需要人工复核的 qa_generated。"""
+        """默认仍停在人工边界；无人值守可自动生成完整候选 PDF。"""
 
         domain = load_domain_pack("atmospheric-science")
         with tempfile.TemporaryDirectory() as directory:
@@ -337,22 +509,91 @@ class WorkflowTest(unittest.TestCase):
                         pdf2zh_bin="/fake/pdf2zh_next",
                         dpi=72,
                     )
-                confirm_reference_run(
-                    run_dir,
-                    additional_segment_ids=[],
-                    confirmed_by="test reviewer",
-                )
                 manifest = run_to_qa(
                     run_dir=run_dir,
                     provider=_Provider(),
                     domain=domain,
                     pdf2zh_bin="/fake/pdf2zh_next",
                     dpi=72,
+                    unattended=True,
                 )
             self.assertEqual(manifest["status"], "qa_generated")
+            self.assertEqual(manifest["execution_mode"], "unattended")
+            self.assertEqual(manifest["unattended_reference_segment_count"], 0)
+            self.assertNotIn("accepted_by", manifest)
             self.assertTrue(Path(str(manifest["qa_report"])).is_file())
             self.assertTrue(
                 (Path(str(manifest["qa_output_dir"])) / "comparisons/page-001.png").is_file()
+            )
+
+    def test_unattended_run_preserves_deterministic_unsafe_segment(self) -> None:
+        """无人值守只自动透传确定性安全清单，不把危险片段交给模型。"""
+
+        domain = load_domain_pack("atmospheric-science")
+        provider = _SafetyProvider()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.pdf"
+            document = canvas.Canvas(str(source))
+            for row in range(24):
+                document.drawString(
+                    40,
+                    780 - row * 24,
+                    f"Synthetic paragraph {row + 1}: visible body text.",
+                )
+            document.save()
+            run_dir = root / "run"
+            initialize_run(
+                source_pdf=source,
+                run_dir=run_dir,
+                source_language="en",
+                target_language="zh-CN",
+            )
+
+            def fake_layout(
+                command: list[str],
+                log_path: Path,
+                timeout_seconds: int = 7200,
+            ) -> None:
+                manifest = load_manifest(run_dir)
+                bridge = command[command.index("--clitranslator-command") + 1]
+                if " collect " in f" {bridge} ":
+                    # 该短 ASCII 对象不在页面可见文字中，必须由安全规则原样保留。
+                    text = "XY"
+                    write_jsonl_atomic(
+                        Path(str(manifest["segments_path"])),
+                        [{"id": segment_id(text), "source": text}],
+                    )
+                    return
+                output = Path(str(manifest["render_output_dir"]))
+                output.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, output / "translated.pdf")
+
+            with (
+                patch("paperlocale.workflow._invoke", side_effect=fake_layout),
+                patch(
+                    "paperlocale.workflow._layout_provenance",
+                    return_value=self.layout_provenance,
+                ),
+            ):
+                manifest = run_to_qa(
+                    run_dir=run_dir,
+                    provider=provider,
+                    domain=domain,
+                    pdf2zh_bin="/fake/pdf2zh_next",
+                    dpi=72,
+                    unattended=True,
+                )
+
+            self.assertEqual(manifest["status"], "qa_generated")
+            self.assertEqual(manifest["unattended_passthrough_segment_count"], 1)
+            self.assertEqual(provider.calls, 0)
+            mapping = json.loads(
+                (run_dir / "passthrough_map.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                mapping["entries"][0]["confirmed_by"],
+                "paperlocale-unattended",
             )
 
     def test_collect_cannot_run_twice(self) -> None:
@@ -504,6 +745,135 @@ class WorkflowTest(unittest.TestCase):
                 domain.content_sha256,
             )
 
+    def test_codex_cli_version_change_resumes_and_records_history(self) -> None:
+        """同模型与推理强度下只变更 CLI 版本时应续跑并留下证据。"""
+
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_pdf = root / "source.pdf"
+            document = canvas.Canvas(str(source_pdf))
+            document.drawString(40, 780, "Soil moisture was 10 mm.")
+            document.drawString(40, 750, "Air temperature was 20 °C.")
+            document.save()
+            run_dir = root / "run"
+            manifest = initialize_run(
+                source_pdf=source_pdf,
+                run_dir=run_dir,
+                source_language="en",
+                target_language="zh-CN",
+            )
+            sources = (
+                "Soil moisture was 10 mm.",
+                "Air temperature was 20 °C.",
+            )
+            write_jsonl_atomic(
+                Path(str(manifest["segments_path"])),
+                [{"id": segment_id(text), "source": text} for text in sources],
+            )
+            manifest["status"] = "collected"
+            save_manifest(run_dir, manifest)
+            confirm_reference_run(
+                run_dir,
+                additional_segment_ids=[],
+                confirmed_by="reviewer",
+            )
+            write_jsonl_atomic(
+                Path(str(manifest["translations_path"])),
+                [
+                    {
+                        "id": segment_id(sources[0]),
+                        "source": sources[0],
+                        "target": "土壤湿度为10 mm。",
+                    }
+                ],
+            )
+            recorded = {
+                "provider": "codex-local",
+                "model": "gpt-5.6-sol",
+                "reasoning_effort": "high",
+                "codex_cli_version": "codex-cli 0.149.0-alpha.4.1",
+            }
+            current = {
+                **recorded,
+                "codex_cli_version": "codex-cli 0.150.0-alpha.8",
+            }
+            manifest["status"] = "collected"
+            manifest["translation_count"] = 1
+            manifest["translation_provider"] = recorded
+            save_manifest(run_dir, manifest)
+
+            result = translate_run(
+                run_dir=run_dir,
+                provider=_ProvenanceProvider(
+                    current,
+                    {sources[1]: "气温为20 °C。"},
+                ),
+                domain=domain,
+            )
+
+            self.assertEqual(result, (1, 1))
+            translated_manifest = load_manifest(run_dir)
+            self.assertEqual(translated_manifest["translation_provider"], recorded)
+            history = translated_manifest["translation_provider_history"]
+            self.assertEqual(
+                [entry["translation_count_before"] for entry in history],
+                [0, 1],
+            )
+            self.assertEqual(history[-1]["provenance"], current)
+
+    def test_codex_model_change_still_rejects_resume(self) -> None:
+        """CLI 兼容补丁不得放宽模型或推理强度身份。"""
+
+        recorded = {
+            "provider": "codex-local",
+            "model": "gpt-5.6-sol",
+            "reasoning_effort": "high",
+            "codex_cli_version": "codex-cli 0.149.0-alpha.4.1",
+        }
+        current = {
+            **recorded,
+            "model": "different-model",
+            "codex_cli_version": "codex-cli 0.150.0-alpha.8",
+        }
+        domain = load_domain_pack("atmospheric-science")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_pdf = root / "source.pdf"
+            document = canvas.Canvas(str(source_pdf))
+            text = "Soil moisture was 10 mm."
+            document.drawString(40, 780, text)
+            document.save()
+            run_dir = root / "run"
+            manifest = initialize_run(
+                source_pdf=source_pdf,
+                run_dir=run_dir,
+                source_language="en",
+                target_language="zh-CN",
+            )
+            write_jsonl_atomic(
+                Path(str(manifest["segments_path"])),
+                [{"id": segment_id(text), "source": text}],
+            )
+            manifest["status"] = "collected"
+            manifest["translation_provider"] = recorded
+            save_manifest(run_dir, manifest)
+            confirm_reference_run(
+                run_dir,
+                additional_segment_ids=[],
+                confirmed_by="reviewer",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Provider 配置"):
+                translate_run(
+                    run_dir=run_dir,
+                    provider=_ProvenanceProvider(
+                        current,
+                        {text: "土壤湿度为10 mm。"},
+                    ),
+                    domain=domain,
+                )
+
     def test_validate_rejects_domain_changed_after_translation(self) -> None:
         """断点续跑不得把翻译时记录的领域包换成另一个同语言包。"""
 
@@ -613,7 +983,7 @@ class WorkflowTest(unittest.TestCase):
                 translate_run(run_dir=run_dir, provider=provider, domain=domain),
                 (0, 1),
             )
-            self.assertEqual(provider.calls, 1)
+            self.assertEqual(provider.calls, 2)
             translated_manifest = load_manifest(run_dir)
             self.assertEqual(translated_manifest["schema_version"], 4)
             self.assertEqual(translated_manifest["passthrough_segment_count"], 1)
@@ -871,6 +1241,187 @@ class WorkflowTest(unittest.TestCase):
                 hashlib.sha256(rendered.read_bytes()).hexdigest(),
             )
 
+    def test_restore_source_vectors_replays_only_missing_paths(self) -> None:
+        """内置修复只处理 QA 明确报告矢量减少的页面。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run_dir, translated, _ = self._make_source_vector_repair_run(root)
+
+            repaired = restore_source_vectors(
+                run_dir,
+                description="restore one missing source line",
+            )
+
+            self.assertEqual(repaired, translated.resolve())
+            repaired_document = fitz.open(repaired)
+            try:
+                self.assertEqual(len(repaired_document[0].get_drawings()), 2)
+                self.assertEqual(len(repaired_document[1].get_drawings()), 1)
+                self.assertEqual(
+                    repaired_document[0].get_text(),
+                    "stable text page 1\n",
+                )
+                self.assertEqual(
+                    repaired_document[1].get_text(),
+                    "stable text page 2\n",
+                )
+            finally:
+                repaired_document.close()
+            repaired_manifest = load_manifest(run_dir)
+            self.assertEqual(repaired_manifest["status"], "rendered")
+            restoration = repaired_manifest["repair_history"][-1][
+                "source_vector_restoration"
+            ]
+            self.assertEqual([item["page"] for item in restoration], [1])
+            self.assertEqual(restoration[0]["restored_count"], 1)
+            self.assertEqual(
+                [
+                    item["page"]
+                    for item in repaired_manifest["repair_history"][-1][
+                        "vector_changes"
+                    ]
+                ],
+                [1],
+            )
+
+    def test_restore_source_vectors_binds_both_qa_hashes(self) -> None:
+        """源或译文哈希任一不属于当前候选时都必须拒绝修复。"""
+
+        for field, message in (
+            ("source_sha256", "不属于当前源 PDF"),
+            ("translated_sha256", "不属于当前译文 PDF"),
+        ):
+            with (
+                self.subTest(field=field),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                run_dir, translated, report_path = self._make_source_vector_repair_run(
+                    Path(directory)
+                )
+                before = translated.read_bytes()
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+                report[field] = "0" * 64
+                report_path.write_text(json.dumps(report), encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, message):
+                    restore_source_vectors(run_dir, description="must reject stale QA")
+
+                self.assertEqual(translated.read_bytes(), before)
+                self.assertNotIn("repair_history", load_manifest(run_dir))
+
+    def test_restore_source_vectors_rejects_qa_without_loss_pages(self) -> None:
+        """QA 没有 source > translated 页时不得生成无依据的矢量修复。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir, translated, report_path = self._make_source_vector_repair_run(
+                Path(directory)
+            )
+            before = translated.read_bytes()
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            for page in report["pages"]:
+                page["translated_vector_drawings"] = page["source_vector_drawings"]
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "没有报告矢量绘图减少页"):
+                restore_source_vectors(run_dir, description="must reject empty gate")
+
+            self.assertEqual(translated.read_bytes(), before)
+            self.assertNotIn("repair_history", load_manifest(run_dir))
+            self.assertEqual(list(run_dir.glob(".source-vector-repair-*.pdf")), [])
+
+    def test_rollback_last_repair_restores_only_chain_tail(self) -> None:
+        """回滚应逆向恢复末项备份、移动历史并解除旧 QA/accept 绑定。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir, rendered, second_backup, qa_report = self._make_repair_chain_run(
+                Path(directory)
+            )
+            original = load_manifest(run_dir)
+            first_entry = original["repair_history"][0]
+            last_entry = original["repair_history"][1]
+
+            result = rollback_last_repair(
+                run_dir,
+                reason="remove audited second repair",
+            )
+
+            updated = load_manifest(run_dir)
+            self.assertEqual(result, rendered.resolve())
+            self.assertEqual(rendered.read_bytes(), second_backup.read_bytes())
+            self.assertEqual(updated["status"], "rendered")
+            self.assertEqual(
+                updated["rendered_sha256"],
+                last_entry["before_sha256"],
+            )
+            self.assertEqual(updated["repair_history"], [first_entry])
+            rolled_back = updated["repair_rollback_history"][-1]
+            self.assertEqual(
+                rolled_back["before_sha256"],
+                last_entry["before_sha256"],
+            )
+            self.assertEqual(
+                rolled_back["after_sha256"],
+                last_entry["after_sha256"],
+            )
+            self.assertEqual(
+                rolled_back["rollback_reason"],
+                "remove audited second repair",
+            )
+            self.assertIn("rolled_back_at", rolled_back)
+            self.assertNotIn("qa_report", updated)
+            self.assertNotIn("accepted_by", updated)
+            # 旧 QA 是审计证据，只从当前清单解绑，不能随回滚一并删除。
+            self.assertTrue(qa_report.is_file())
+            self.assertTrue(json.loads(qa_report.read_text())["visual_accepted"])
+            self.assertEqual(list(run_dir.glob(".rollback-current-*.pdf")), [])
+            self.assertEqual(list(rendered.parent.glob("*.rollback.tmp")), [])
+
+    def test_rollback_last_repair_requires_current_tail_after_hash(self) -> None:
+        """当前 PDF 即使哈希自洽，也不能跳过修复链末项直接回滚前项。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir, rendered, second_backup, _ = self._make_repair_chain_run(
+                Path(directory)
+            )
+            rendered.write_bytes(second_backup.read_bytes())
+            manifest = load_manifest(run_dir)
+            manifest["rendered_sha256"] = hashlib.sha256(
+                rendered.read_bytes()
+            ).hexdigest()
+            save_manifest(run_dir, manifest)
+
+            with self.assertRaisesRegex(ValueError, "已不是最后一次修复的产物"):
+                rollback_last_repair(run_dir, reason="must not skip chain tail")
+
+            self.assertEqual(len(load_manifest(run_dir)["repair_history"]), 2)
+
+    def test_rollback_last_repair_validates_backup_presence_and_hash(self) -> None:
+        """链尾备份缺失或不等于 before 哈希时不得改写当前 PDF。"""
+
+        for scenario in ("missing", "wrong-hash"):
+            with (
+                self.subTest(scenario=scenario),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                run_dir, rendered, second_backup, _ = self._make_repair_chain_run(
+                    Path(directory)
+                )
+                before = rendered.read_bytes()
+                if scenario == "missing":
+                    second_backup.unlink()
+                else:
+                    second_backup.write_bytes(b"not-the-bound-before-pdf")
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "备份不存在或哈希不一致",
+                ):
+                    rollback_last_repair(run_dir, reason="must reject invalid backup")
+
+                self.assertEqual(rendered.read_bytes(), before)
+                self.assertEqual(len(load_manifest(run_dir)["repair_history"]), 2)
+
     def test_apply_text_repair_subsets_font_and_resets_qa(self) -> None:
         """文字修复必须备份旧 PDF、子集字体并留下可追溯记录。"""
 
@@ -956,6 +1507,42 @@ class WorkflowTest(unittest.TestCase):
                 hashlib.sha256(rendered.read_bytes()).hexdigest(),
             )
             self.assertEqual(list(run_dir.glob(".text-repair-*.pdf")), [])
+
+    def test_apply_text_repair_single_line_uses_font_metrics(self) -> None:
+        """浅矩形单行模式应按子集字体实际宽高写入，不触发换行。"""
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            run_dir, rendered, _rectangle, font_file = self._make_text_repair_run(root)
+            document = fitz.open(rendered)
+            try:
+                found = document[0].search_for(
+                    "FiguFigure 5 broken caption perio d"
+                )[0]
+                shallow = (35.0, found.y0, 300.0, found.y0 + 10.0)
+            finally:
+                document.close()
+
+            apply_text_repair(
+                run_dir,
+                page_number=1,
+                rectangle=shallow,
+                replacement="Figure 5 corrected caption",
+                font_file=font_file,
+                font_size=7.0,
+                description="single-line shallow repair",
+                single_line=True,
+            )
+
+            repaired = fitz.open(rendered)
+            try:
+                self.assertIn("Figure 5 corrected caption", repaired[0].get_text())
+                self.assertNotIn("broken caption", repaired[0].get_text())
+            finally:
+                repaired.close()
+            history = load_manifest(run_dir)["repair_history"][-1]
+            self.assertEqual(history["placement_mode"], "single-line")
+            self.assertLessEqual(history["text_height"], shallow[3] - shallow[1])
 
     def test_apply_text_repair_can_remove_a_bound_fragment_without_font(self) -> None:
         """只删除模式必须严格限定矩形，且不嵌入空字体子集。"""


### PR DESCRIPTION
## Summary

- add the whole-document `--unattended` candidate workflow while preserving the mandatory human visual-acceptance gate;
- make Provider CLI compatibility and saved-run resume behavior explicit and testable;
- add QA-bound source-vector restoration, reversible repair history, `rollback-last-repair`, and single-line text repair;
- update version metadata, changelog, English/Chinese documentation, and v0.4.2 release notes.

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -v`: 119 tests passed;
- `compileall`, Ruff `F,I`, and `git diff --check`: passed;
- wheel and sdist built with Python 3.12 and passed `twine check`;
- exact wheel installed in a clean environment; package metadata, CLI version, new commands, dependency integrity, and layout dependency resolution passed;
- Paper 18 completed 14/14 machine QA, full-page visual review, PaperLocale `accept`, and final atomic-copy verification; accepted PDF SHA-256: `2b0586ddf5266cf81ebf490181a254e22588ef5d6565db04db12d67c6a873b91`.

`ruff format --check` is not a configured repository/CI gate and would reformat pre-existing baseline files, so no unrelated bulk formatting is included.
